### PR TITLE
♻️ Reduce Ocean Wave interface noise

### DIFF
--- a/server/src/client/src/App.tsx
+++ b/server/src/client/src/App.tsx
@@ -1,8 +1,10 @@
 import axios from 'axios';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useStore } from 'badland-react';
 import { RouterProvider } from 'react-router-dom';
 
 import AuthGate from './components/auth/AuthGate';
+import SplashScreen from './components/app/SplashScreen/SplashScreen';
 import { MusicListener, socket } from './socket';
 
 import router from './router';
@@ -19,6 +21,7 @@ import { albumStore } from './store/album';
 import { Providers } from './components/app';
 
 const AUTH_RECOVERY_PATH_PREFIX = '/api/auth/';
+const SPLASH_MIN_MS = 1200;
 
 export default function App() {
     const [authSession, setAuthSession] = useState<AuthSession | null>(null);
@@ -26,6 +29,16 @@ export default function App() {
     const [authErrorMessage, setAuthErrorMessage] = useState<string | null>(null);
     const [isAuthLoading, setIsAuthLoading] = useState(true);
     const [isSubmittingPassword, setIsSubmittingPassword] = useState(false);
+    const [showSplash, setShowSplash] = useState(true);
+    const [splashExiting, setSplashExiting] = useState(false);
+    const splashStartTime = useRef(Date.now());
+
+    const canAccessApp = Boolean(
+        authSession && (!authSession.authRequired || authSession.authenticated)
+    );
+
+    // Watch music store — only meaningful after canAccessApp
+    const [{ loaded: musicLoaded }] = useStore(musicStore);
 
     const refreshAuthSession = async () => {
         setIsAuthLoading(true);
@@ -83,15 +96,29 @@ export default function App() {
         };
     }, []);
 
-    const canAccessApp = Boolean(
-        authSession && (!authSession.authRequired || authSession.authenticated)
-    );
+    // Splash exit: auth done + (music loaded OR auth failed) + minimum time
+    useEffect(() => {
+        if (!showSplash) return;
+
+        const authDone = !isAuthLoading;
+        const storesDone = !canAccessApp || musicLoaded;
+
+        if (!authDone || !storesDone) return;
+
+        const elapsed = Date.now() - splashStartTime.current;
+        const remaining = Math.max(0, SPLASH_MIN_MS - elapsed);
+
+        const exitTimer = setTimeout(() => {
+            setSplashExiting(true);
+            setTimeout(() => setShowSplash(false), 440);
+        }, remaining);
+
+        return () => clearTimeout(exitTimer);
+    }, [isAuthLoading, canAccessApp, musicLoaded, showSplash]);
 
     useEffect(() => {
         const handleWindowFocus = () => {
-            if (!canAccessApp) {
-                return;
-            }
+            if (!canAccessApp) return;
 
             if (!socket.connected) {
                 socket.connect();
@@ -148,34 +175,43 @@ export default function App() {
         }
     };
 
-    if (isAuthLoading) {
-        return <AuthGate state="loading" />;
-    }
+    const appContent = () => {
+        if (authBootstrapError || (!isAuthLoading && !authSession)) {
+            return (
+                <AuthGate
+                    state="error"
+                    errorMessage={authBootstrapError}
+                    onRetry={refreshAuthSession}
+                />
+            );
+        }
 
-    if (authBootstrapError || !authSession) {
-        return (
-            <AuthGate
-                state="error"
-                errorMessage={authBootstrapError}
-                onRetry={refreshAuthSession}
-            />
-        );
-    }
+        if (!isAuthLoading && authSession?.authRequired && !authSession.authenticated) {
+            return (
+                <AuthGate
+                    state="login"
+                    errorMessage={authErrorMessage}
+                    isSubmitting={isSubmittingPassword}
+                    onSubmit={handlePasswordSubmit}
+                />
+            );
+        }
 
-    if (authSession.authRequired && !authSession.authenticated) {
-        return (
-            <AuthGate
-                state="login"
-                errorMessage={authErrorMessage}
-                isSubmitting={isSubmittingPassword}
-                onSubmit={handlePasswordSubmit}
-            />
-        );
-    }
+        if (canAccessApp) {
+            return (
+                <Providers>
+                    <RouterProvider router={router} />
+                </Providers>
+            );
+        }
+
+        return null;
+    };
 
     return (
-        <Providers>
-            <RouterProvider router={router} />
-        </Providers>
+        <>
+            {showSplash && <SplashScreen isExiting={splashExiting} />}
+            {appContent()}
+        </>
     );
 }

--- a/server/src/client/src/components/album/AlbumListItem/AlbumListItem.module.scss
+++ b/server/src/client/src/components/album/AlbumListItem/AlbumListItem.module.scss
@@ -9,19 +9,14 @@
     overflow: hidden;
     box-shadow: var.$SHADOW_MAIN;
     transition: var.$TRANSITION_FAST;
-    transition-property: transform, box-shadow;
+    transition-property: box-shadow;
 
     &:hover {
-        transform: translateY(-4px);
         box-shadow: var.$SHADOW_HOVER;
-
-        .cover {
-            transform: scale(1.02);
-        }
     }
 
     &:active {
-        transform: translateY(-2px) scale(0.99);
+        transform: scale(0.98);
     }
 
     .cover-wrapper {
@@ -33,7 +28,6 @@
         width: 100%;
         height: 100%;
         object-fit: cover;
-        transition: transform var.$TRANSITION_NORMAL;
     }
 
     .info {

--- a/server/src/client/src/components/album/AlbumSummary/AlbumSummary.module.scss
+++ b/server/src/client/src/components/album/AlbumSummary/AlbumSummary.module.scss
@@ -17,9 +17,7 @@
             aspect-ratio: 1;
             border-radius: var.$RADIUS_XL;
             overflow: hidden;
-            box-shadow:
-                0 20px 60px rgba(0, 0, 0, 0.6),
-                0 8px 24px rgba(0, 0, 0, 0.4);
+            box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
 
             &::after {
                 content: '';
@@ -35,11 +33,6 @@
             width: 100%;
             height: 100%;
             object-fit: cover;
-            transition: transform var.$TRANSITION_SLOW;
-        }
-
-        &:hover img {
-            transform: scale(1.02);
         }
     }
 

--- a/server/src/client/src/components/app/ConfirmProvider.module.scss
+++ b/server/src/client/src/components/app/ConfirmProvider.module.scss
@@ -32,18 +32,11 @@
 }
 
 .title {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
-    line-height: 1.35;
     letter-spacing: -0.01em;
 }
 
 .description {
-    margin: 0;
-    font-size: 0.875rem;
-    line-height: 1.5;
-    color: var.$COLOR_TEXT_SECONDARY;
+    line-height: var.$LINE_HEIGHT_DEFAULT;
 }
 
 .actions {
@@ -54,42 +47,7 @@
 }
 
 .button {
-    min-height: 44px;
-    padding: 0.625rem 0.95rem;
-    border-radius: var.$RADIUS_FULL;
-    border: 1px solid var.$COLOR_BORDER_SUBTLE;
-    font: inherit;
-    font-size: 0.8125rem;
-    font-weight: 600;
-    transition: var.$TRANSITION_FAST;
-    transition-property: background-color, border-color, color;
-}
-
-.secondary {
-    background:
-        linear-gradient(180deg, rgba(10, 36, 45, 0.86) 0%, rgba(7, 27, 35, 0.92) 100%);
-    color: var.$COLOR_TEXT;
-
-    &:hover {
-        border-color: var.$COLOR_BORDER;
-        background:
-            linear-gradient(180deg, rgba(12, 44, 55, 0.9) 0%, rgba(9, 33, 42, 0.96) 100%);
-    }
-}
-
-.primary {
-    border-color: transparent;
-    background: var(--b-gradient-primary);
-    color: #03212b;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
-}
-
-.danger {
-    background: linear-gradient(180deg, rgba(242, 121, 121, 0.96) 0%, rgba(230, 89, 89, 1) 100%);
-    color: #190505;
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.2),
-        0 14px 28px rgba(125, 20, 20, 0.24);
+    min-width: 5.5rem;
 }
 
 @media (max-width: 640px) {

--- a/server/src/client/src/components/app/ConfirmProvider.module.scss
+++ b/server/src/client/src/components/app/ConfirmProvider.module.scss
@@ -16,11 +16,10 @@
     width: min(calc(100vw - 1.5rem), 26rem);
     transform: translate(-50%, -50%);
     z-index: 121;
-    border-radius: 1.25rem;
+    border-radius: var.$RADIUS_LG;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
-    background:
-        linear-gradient(180deg, rgba(8, 28, 36, 0.96) 0%, rgba(5, 20, 28, 0.98) 100%);
-    box-shadow: var.$SHADOW_MAIN;
+    background: rgba(8, 28, 36, 0.97);
+    box-shadow: var.$SHADOW_SUB;
     padding: 1rem;
     color: var.$COLOR_TEXT;
     animation: confirm-in 220ms ease;
@@ -63,15 +62,7 @@
     font-size: 0.8125rem;
     font-weight: 600;
     transition: var.$TRANSITION_FAST;
-    transition-property: transform, background-color, border-color, box-shadow, color;
-
-    &:hover {
-        transform: translateY(-1px);
-    }
-
-    &:active {
-        transform: translateY(0);
-    }
+    transition-property: background-color, border-color, color;
 }
 
 .secondary {
@@ -90,9 +81,7 @@
     border-color: transparent;
     background: var(--b-gradient-primary);
     color: #03212b;
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.38),
-        0 14px 28px rgba(29, 153, 178, 0.2);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
 .danger {

--- a/server/src/client/src/components/app/ConfirmProvider.tsx
+++ b/server/src/client/src/components/app/ConfirmProvider.tsx
@@ -21,7 +21,14 @@ export default function ConfirmProvider() {
                 }
             }}>
             <AlertDialog.Portal>
-                <AlertDialog.Overlay className={styles.overlay} />
+                <AlertDialog.Overlay
+                    className={styles.overlay}
+                    onClick={() => {
+                        if (options.tone !== 'danger') {
+                            confirmStore.cancelIfOpen();
+                        }
+                    }}
+                />
 
                 <AlertDialog.Content className={styles.content}>
                     <div className={styles.header}>

--- a/server/src/client/src/components/app/ConfirmProvider.tsx
+++ b/server/src/client/src/components/app/ConfirmProvider.tsx
@@ -1,6 +1,7 @@
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import { useStore } from 'badland-react';
 
+import { Button, Text } from '~/components/shared';
 import { confirmStore } from '~/modules/confirm';
 
 import styles from './ConfirmProvider.module.scss';
@@ -32,34 +33,38 @@ export default function ConfirmProvider() {
 
                 <AlertDialog.Content className={styles.content}>
                     <div className={styles.header}>
-                        <AlertDialog.Title className={styles.title}>
-                            {options.title}
+                        <AlertDialog.Title asChild>
+                            <Text as="h2" size="base" weight="semibold" className={styles.title}>
+                                {options.title}
+                            </Text>
                         </AlertDialog.Title>
 
                         {options.description && (
-                            <AlertDialog.Description className={styles.description}>
-                                {options.description}
+                            <AlertDialog.Description asChild>
+                                <Text as="p" variant="secondary" size="sm" className={styles.description}>
+                                    {options.description}
+                                </Text>
                             </AlertDialog.Description>
                         )}
                     </div>
 
                     <div className={styles.actions}>
                         <AlertDialog.Cancel asChild>
-                            <button
-                                type="button"
-                                className={`${styles.button} ${styles.secondary}`}
+                            <Button
+                                className={styles.button}
+                                variant="secondary"
                                 onClick={() => confirmStore.resolve(false)}>
                                 {options.cancelLabel}
-                            </button>
+                            </Button>
                         </AlertDialog.Cancel>
 
                         <AlertDialog.Action asChild>
-                            <button
-                                type="button"
-                                className={`${styles.button} ${styles.primary} ${options.tone === 'danger' ? styles.danger : ''}`}
+                            <Button
+                                className={styles.button}
+                                variant={options.tone === 'danger' ? 'danger' : 'primary'}
                                 onClick={() => confirmStore.resolve(true)}>
                                 {options.confirmLabel}
-                            </button>
+                            </Button>
                         </AlertDialog.Action>
                     </div>
                 </AlertDialog.Content>

--- a/server/src/client/src/components/app/PromptProvider.module.scss
+++ b/server/src/client/src/components/app/PromptProvider.module.scss
@@ -38,30 +38,23 @@
 }
 
 .title {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
-    line-height: 1.35;
     letter-spacing: -0.01em;
 }
 
 .description {
-    margin: 0;
-    font-size: 0.875rem;
-    line-height: 1.5;
-    color: var.$COLOR_TEXT_SECONDARY;
+    line-height: var.$LINE_HEIGHT_DEFAULT;
 }
 
 .input {
     width: 100%;
-    min-height: 48px;
+    min-height: var.$CONTROL_HEIGHT_LG;
     padding: 0.875rem 1rem;
     border-radius: 1rem;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
     background: rgba(10, 36, 45, 0.78);
     color: var.$COLOR_TEXT;
     font: inherit;
-    font-size: 0.9375rem;
+    font-size: var.$TEXT_SIZE_MD;
     transition: var.$TRANSITION_FAST;
     transition-property: border-color, box-shadow, background-color;
 
@@ -84,28 +77,7 @@
 }
 
 .button {
-    min-height: 44px;
-    padding: 0.625rem 0.95rem;
-    border-radius: var.$RADIUS_FULL;
-    border: 1px solid var.$COLOR_BORDER_SUBTLE;
-    font: inherit;
-    font-size: 0.8125rem;
-    font-weight: 600;
-    transition: var.$TRANSITION_FAST;
-    transition-property: background-color, border-color, color;
-}
-
-.secondary {
-    background:
-        linear-gradient(180deg, rgba(10, 36, 45, 0.86) 0%, rgba(7, 27, 35, 0.92) 100%);
-    color: var.$COLOR_TEXT;
-}
-
-.primary {
-    border-color: transparent;
-    background: var(--b-gradient-primary);
-    color: #03212b;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    min-width: 5.5rem;
 }
 
 @media (max-width: 640px) {

--- a/server/src/client/src/components/app/PromptProvider.module.scss
+++ b/server/src/client/src/components/app/PromptProvider.module.scss
@@ -16,11 +16,10 @@
     width: min(calc(100vw - 1.5rem), 28rem);
     transform: translate(-50%, -50%);
     z-index: 123;
-    border-radius: 1.25rem;
+    border-radius: var.$RADIUS_LG;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
-    background:
-        linear-gradient(180deg, rgba(8, 28, 36, 0.96) 0%, rgba(5, 20, 28, 0.98) 100%);
-    box-shadow: var.$SHADOW_MAIN;
+    background: rgba(8, 28, 36, 0.97);
+    box-shadow: var.$SHADOW_SUB;
     padding: 1rem;
     color: var.$COLOR_TEXT;
     animation: dialog-in 220ms ease;
@@ -93,15 +92,7 @@
     font-size: 0.8125rem;
     font-weight: 600;
     transition: var.$TRANSITION_FAST;
-    transition-property: transform, background-color, border-color, box-shadow, color;
-
-    &:hover {
-        transform: translateY(-1px);
-    }
-
-    &:active {
-        transform: translateY(0);
-    }
+    transition-property: background-color, border-color, color;
 }
 
 .secondary {
@@ -114,9 +105,7 @@
     border-color: transparent;
     background: var(--b-gradient-primary);
     color: #03212b;
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.38),
-        0 14px 28px rgba(29, 153, 178, 0.2);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
 @media (max-width: 640px) {

--- a/server/src/client/src/components/app/PromptProvider.tsx
+++ b/server/src/client/src/components/app/PromptProvider.tsx
@@ -2,6 +2,7 @@ import * as Dialog from '@radix-ui/react-dialog';
 import { useStore } from 'badland-react';
 import { useEffect, useRef, useState } from 'react';
 
+import { Button, Text } from '~/components/shared';
 import { promptStore } from '~/modules/prompt';
 
 import styles from './PromptProvider.module.scss';
@@ -49,13 +50,17 @@ export default function PromptProvider() {
                             promptStore.resolve(value.trim());
                         }}>
                         <div className={styles.header}>
-                            <Dialog.Title className={styles.title}>
-                                {options.title}
+                            <Dialog.Title asChild>
+                                <Text as="h2" size="base" weight="semibold" className={styles.title}>
+                                    {options.title}
+                                </Text>
                             </Dialog.Title>
 
                             {options.description && (
-                                <Dialog.Description className={styles.description}>
-                                    {options.description}
+                                <Dialog.Description asChild>
+                                    <Text as="p" variant="secondary" size="sm" className={styles.description}>
+                                        {options.description}
+                                    </Text>
                                 </Dialog.Description>
                             )}
                         </div>
@@ -70,19 +75,20 @@ export default function PromptProvider() {
 
                         <div className={styles.actions}>
                             <Dialog.Close asChild>
-                                <button
-                                    type="button"
-                                    className={`${styles.button} ${styles.secondary}`}
+                                <Button
+                                    className={styles.button}
+                                    variant="secondary"
                                     onClick={() => promptStore.resolve(null)}>
                                     {options.cancelLabel}
-                                </button>
+                                </Button>
                             </Dialog.Close>
 
-                            <button
+                            <Button
                                 type="submit"
-                                className={`${styles.button} ${styles.primary}`}>
+                                className={styles.button}
+                                variant="primary">
                                 {options.confirmLabel}
-                            </button>
+                            </Button>
                         </div>
                     </form>
                 </Dialog.Content>

--- a/server/src/client/src/components/app/SplashScreen/SplashScreen.module.scss
+++ b/server/src/client/src/components/app/SplashScreen/SplashScreen.module.scss
@@ -1,0 +1,90 @@
+@use '~/styles/var';
+
+.splash {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #03141b;
+    animation: fade-in 300ms ease both;
+
+    &.exiting {
+        animation: slide-up 420ms cubic-bezier(0.4, 0, 0.2, 1) both;
+        pointer-events: none;
+    }
+}
+
+.content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+    animation: content-in 500ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation-delay: 80ms;
+
+    .exiting & {
+        animation: none;
+    }
+}
+
+.icon {
+    width: 72px;
+    height: 72px;
+    border-radius: 22px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--b-gradient-primary);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.28),
+        0 24px 48px rgba(29, 153, 178, 0.2);
+
+    svg {
+        width: 34px;
+        height: 34px;
+        color: #03202a;
+    }
+}
+
+.name {
+    font-size: 1.75rem;
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    color: var.$COLOR_TEXT;
+}
+
+@keyframes fade-in {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes content-in {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes slide-up {
+    from {
+        opacity: 1;
+        transform: translateY(0);
+    }
+
+    to {
+        opacity: 0;
+        transform: translateY(-24px);
+    }
+}

--- a/server/src/client/src/components/app/SplashScreen/SplashScreen.tsx
+++ b/server/src/client/src/components/app/SplashScreen/SplashScreen.tsx
@@ -1,0 +1,21 @@
+import { Music } from '~/icon';
+import { appShell } from '~/config/app-shell';
+
+import styles from './SplashScreen.module.scss';
+
+interface SplashScreenProps {
+    isExiting: boolean;
+}
+
+export default function SplashScreen({ isExiting }: SplashScreenProps) {
+    return (
+        <div className={`${styles.splash} ${isExiting ? styles.exiting : ''}`}>
+            <div className={styles.content}>
+                <div className={styles.icon}>
+                    <Music />
+                </div>
+                <span className={styles.name}>{appShell.brand.name}</span>
+            </div>
+        </div>
+    );
+}

--- a/server/src/client/src/components/artist/ArtistListItem/ArtistListItem.module.scss
+++ b/server/src/client/src/components/artist/ArtistListItem/ArtistListItem.module.scss
@@ -13,14 +13,6 @@
 
     &:hover {
         background-color: var.$COLOR_HOVER;
-
-        .image {
-            transform: scale(1.05);
-        }
-
-        .image-container {
-            box-shadow: 0 0 20px rgba(167, 139, 250, 0.15);
-        }
     }
 
     &:active {
@@ -33,14 +25,12 @@
         border-radius: var.$RADIUS_FULL;
         overflow: hidden;
         flex-shrink: 0;
-        transition: box-shadow var.$TRANSITION_FAST;
     }
 
     .image {
         width: 100%;
         height: 100%;
         object-fit: cover;
-        transition: transform var.$TRANSITION_NORMAL;
     }
 
     .info {

--- a/server/src/client/src/components/artist/ArtistSummary/ArtistSummary.module.scss
+++ b/server/src/client/src/components/artist/ArtistSummary/ArtistSummary.module.scss
@@ -17,9 +17,7 @@
             aspect-ratio: 1;
             border-radius: var.$RADIUS_FULL;
             overflow: hidden;
-            box-shadow:
-                0 20px 60px rgba(0, 0, 0, 0.6),
-                0 8px 24px rgba(0, 0, 0, 0.4);
+            box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
 
             &::after {
                 content: '';
@@ -35,11 +33,6 @@
             width: 100%;
             height: 100%;
             object-fit: cover;
-            transition: transform var.$TRANSITION_SLOW;
-        }
-
-        &:hover img {
-            transform: scale(1.02);
         }
     }
 

--- a/server/src/client/src/components/auth/AuthGate.module.scss
+++ b/server/src/client/src/components/auth/AuthGate.module.scss
@@ -117,11 +117,10 @@
     transition-property: transform, box-shadow, filter;
 
     &:hover:not(:disabled) {
-        transform: translateY(-1px);
-        filter: saturate(1.04);
+        filter: saturate(1.04) brightness(1.04);
         box-shadow:
             inset 0 1px 0 rgba(255, 255, 255, 0.44),
-            0 22px 40px rgba(22, 120, 144, 0.34);
+            0 18px 36px rgba(22, 120, 144, 0.34);
     }
 
     &:active:not(:disabled) {

--- a/server/src/client/src/components/layout/TwoToneLayout/TwoToneLayout.module.scss
+++ b/server/src/client/src/components/layout/TwoToneLayout/TwoToneLayout.module.scss
@@ -58,10 +58,10 @@
             color: var.$COLOR_TEXT;
             cursor: pointer;
             box-shadow:
-                0 8px 24px rgba(167, 139, 250, 0.3),
+                0 8px 24px rgba(29, 153, 178, 0.25),
                 0 4px 12px rgba(0, 0, 0, 0.4);
             transition: var.$TRANSITION_FAST;
-            transition-property: transform, box-shadow, filter;
+            transition-property: box-shadow, filter;
 
             svg {
                 width: 28px;
@@ -69,10 +69,9 @@
             }
 
             &:hover {
-                transform: scale(1.05);
                 filter: brightness(1.1);
                 box-shadow:
-                    0 12px 32px rgba(167, 139, 250, 0.4),
+                    0 12px 32px rgba(29, 153, 178, 0.32),
                     0 6px 16px rgba(0, 0, 0, 0.5);
             }
 

--- a/server/src/client/src/components/music/MusicListItem/MusicListItem.module.scss
+++ b/server/src/client/src/components/music/MusicListItem/MusicListItem.module.scss
@@ -34,11 +34,6 @@ $SIZE_ICON: 40px;
         border-radius: var.$RADIUS_MD;
         object-fit: cover;
         flex-shrink: 0;
-        transition: transform var.$TRANSITION_FAST;
-    }
-
-    &:hover .album-art {
-        transform: scale(1.02);
     }
 
     .row {

--- a/server/src/client/src/components/music/MusicSelector/MusicSelector.module.scss
+++ b/server/src/client/src/components/music/MusicSelector/MusicSelector.module.scss
@@ -9,7 +9,7 @@
     font-size: 0.8rem;
 
     &.active {
-        color: var.$COLOR_PURPLE_PROMINENT;
+        color: var.$COLOR_POINT;
     }
 
     svg {

--- a/server/src/client/src/components/playlist/PlaylistItem/PlaylistItem.module.scss
+++ b/server/src/client/src/components/playlist/PlaylistItem/PlaylistItem.module.scss
@@ -3,9 +3,9 @@
 $SIZE_ICON: 40px;
 
 .PlaylistItem {
-    color: #eee;
-    font-size: 14px;
-    padding: 16px;
+    color: var.$COLOR_TEXT;
+    font-size: 0.875rem;
+    padding: 1rem;
     display: flex;
     align-items: center;
     gap: 1rem;
@@ -27,7 +27,7 @@ $SIZE_ICON: 40px;
 
     .count {
         font-size: 0.875rem;
-        color: #aaa;
+        color: var.$COLOR_TEXT_TERTIARY;
     }
 
     .cover {

--- a/server/src/client/src/components/shared/ActionBar/ActionBar.module.scss
+++ b/server/src/client/src/components/shared/ActionBar/ActionBar.module.scss
@@ -8,7 +8,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 0.5rem 0;
-    background-color: var.$COLOR_PURPLE_PROMINENT;
+    background-color: rgba(7, 25, 33, 0.96);
 
     button {
         display: flex;
@@ -16,7 +16,7 @@
         flex-direction: column;
         justify-content: center;
         font-size: 0.75rem;
-        font-weight: bold;
+        font-weight: 700;
         gap: 0.25rem;
 
         svg {

--- a/server/src/client/src/components/shared/ActionBar/ActionBar.module.scss
+++ b/server/src/client/src/components/shared/ActionBar/ActionBar.module.scss
@@ -15,8 +15,8 @@
         align-items: center;
         flex-direction: column;
         justify-content: center;
-        font-size: 0.75rem;
-        font-weight: 700;
+        font-size: var.$TEXT_SIZE_XS;
+        font-weight: var.$FONT_WEIGHT_BOLD;
         gap: 0.25rem;
 
         svg {

--- a/server/src/client/src/components/shared/BottomPanel/BottomPanel.module.scss
+++ b/server/src/client/src/components/shared/BottomPanel/BottomPanel.module.scss
@@ -22,9 +22,8 @@
     border-radius: 1.25rem 1.25rem 0 0;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
     border-bottom: 0;
-    background:
-        linear-gradient(180deg, rgba(8, 28, 36, 0.98) 0%, rgba(5, 20, 28, 0.99) 100%);
-    box-shadow: var.$SHADOW_MAIN;
+    background: rgba(7, 25, 33, 0.98);
+    box-shadow: var.$SHADOW_SUB;
     color: var.$COLOR_TEXT;
     z-index: 111;
     overflow: hidden;

--- a/server/src/client/src/components/shared/BottomPanel/BottomPanel.module.scss
+++ b/server/src/client/src/components/shared/BottomPanel/BottomPanel.module.scss
@@ -61,8 +61,8 @@
 .title {
     margin: 0;
     width: 100%;
-    font-size: 0.8125rem;
-    font-weight: 600;
+    font-size: var.$TEXT_SIZE_SM;
+    font-weight: var.$FONT_WEIGHT_SEMIBOLD;
     color: var.$COLOR_TEXT_SECONDARY;
     letter-spacing: 0.01em;
     text-align: left;

--- a/server/src/client/src/components/shared/Button/Button.module.scss
+++ b/server/src/client/src/components/shared/Button/Button.module.scss
@@ -1,27 +1,37 @@
 @use '~/styles/var';
 
 .Button {
-    min-height: 44px;
+    min-height: var.$CONTROL_HEIGHT_MD;
     padding: 0.625rem 0.875rem;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
-    background:
-        linear-gradient(180deg, rgba(10, 36, 45, 0.86) 0%, rgba(7, 27, 35, 0.92) 100%);
     border-radius: var.$RADIUS_FULL;
     color: var.$COLOR_TEXT;
-    font-size: 0.875rem;
-    font-weight: 600;
-    display: flex;
-    flex-direction: row;
+    font: inherit;
+    font-size: var.$TEXT_SIZE_SM;
+    font-weight: var.$FONT_WEIGHT_SEMIBOLD;
+    line-height: var.$LINE_HEIGHT_HEADING;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
+    text-decoration: none;
+    background:
+        linear-gradient(180deg, rgba(10, 36, 45, 0.86) 0%, rgba(7, 27, 35, 0.92) 100%);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
     transition: var.$TRANSITION_FAST;
-    transition-property: background-color, border-color, color;
+    transition-property: background-color, border-color, color, box-shadow;
 
     svg {
         width: 1rem;
         height: 1rem;
+    }
+
+    &:focus-visible {
+        outline: none;
+        border-color: var.$COLOR_FOCUS;
+        box-shadow:
+            inset 0 1px 0 rgba(255, 255, 255, 0.04),
+            0 0 0 3px rgba(114, 215, 230, 0.14);
     }
 
     &:hover {
@@ -30,15 +40,43 @@
             linear-gradient(180deg, rgba(12, 44, 55, 0.9) 0%, rgba(9, 33, 42, 0.96) 100%);
     }
 
-    &.primary {
+    &.size-sm {
+        min-height: var.$CONTROL_HEIGHT_SM;
+        padding: 0.5rem 0.75rem;
+    }
+
+    &.size-md {
+        min-height: var.$CONTROL_HEIGHT_MD;
+    }
+
+    &.fullWidth {
+        width: 100%;
+    }
+
+    &.variant-primary {
         color: #03212b;
         border-color: transparent;
         background: var(--b-gradient-primary);
         box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
     }
 
-    &.secondary {
+    &.variant-primary:hover {
+        color: #03212b;
+        border-color: transparent;
+        background: var(--b-gradient-primary);
+    }
+
+    &.variant-secondary {
         background-color: var.$COLOR_SECONDARY_BUTTON;
+    }
+
+    &.variant-danger {
+        border-color: transparent;
+        background: linear-gradient(180deg, rgba(242, 121, 121, 0.96) 0%, rgba(230, 89, 89, 1) 100%);
+        color: #190505;
+        box-shadow:
+            inset 0 1px 0 rgba(255, 255, 255, 0.2),
+            0 14px 28px rgba(125, 20, 20, 0.18);
     }
 
     &:disabled {

--- a/server/src/client/src/components/shared/Button/Button.module.scss
+++ b/server/src/client/src/components/shared/Button/Button.module.scss
@@ -8,18 +8,16 @@
         linear-gradient(180deg, rgba(10, 36, 45, 0.86) 0%, rgba(7, 27, 35, 0.92) 100%);
     border-radius: var.$RADIUS_FULL;
     color: var.$COLOR_TEXT;
-    font-size: 0.8125rem;
+    font-size: 0.875rem;
     font-weight: 600;
     display: flex;
     flex-direction: row;
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.04),
-        0 12px 24px rgba(2, 8, 11, 0.12);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
     transition: var.$TRANSITION_FAST;
-    transition-property: transform, background-color, border-color, box-shadow, color;
+    transition-property: background-color, border-color, color;
 
     svg {
         width: 1rem;
@@ -30,29 +28,22 @@
         border-color: var.$COLOR_BORDER;
         background:
             linear-gradient(180deg, rgba(12, 44, 55, 0.9) 0%, rgba(9, 33, 42, 0.96) 100%);
-        box-shadow:
-            inset 0 1px 0 rgba(255, 255, 255, 0.06),
-            0 16px 28px rgba(2, 8, 11, 0.18);
-        transform: translateY(-1px);
-    }
-
-    &:active {
-        transform: translateY(0);
-        box-shadow:
-            inset 0 1px 0 rgba(255, 255, 255, 0.04),
-            0 8px 16px rgba(2, 8, 11, 0.14);
     }
 
     &.primary {
         color: #03212b;
         border-color: transparent;
         background: var(--b-gradient-primary);
-        box-shadow:
-            inset 0 1px 0 rgba(255, 255, 255, 0.42),
-            0 18px 32px rgba(29, 153, 178, 0.26);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.3);
     }
 
     &.secondary {
         background-color: var.$COLOR_SECONDARY_BUTTON;
+    }
+
+    &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+        pointer-events: none;
     }
 }

--- a/server/src/client/src/components/shared/Button/Button.tsx
+++ b/server/src/client/src/components/shared/Button/Button.tsx
@@ -4,31 +4,41 @@ const cx = classNames.bind(styles);
 
 import React from 'react';
 
-interface ButtonProps {
-    type?: 'primary' | 'secondary';
-    disabled?: boolean;
-    style?: React.CSSProperties;
-    children?: React.ReactNode;
-    onClick?: () => void;
+type ButtonVariant = 'primary' | 'secondary' | 'danger';
+type ButtonSize = 'sm' | 'md';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+    variant?: ButtonVariant;
+    size?: ButtonSize;
+    fullWidth?: boolean;
 }
 
-const Button = ({
-    type='secondary',
-    disabled,
-    style,
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({
+    variant = 'secondary',
+    size = 'md',
+    fullWidth = false,
+    className,
+    type = 'button',
     children,
-    onClick
-}: ButtonProps) => {
+    ...props
+}, ref) => {
     return (
         <button
-            type="button"
-            disabled={disabled}
-            style={style}
-            className={cx('Button', type)}
-            onClick={onClick}>
+            ref={ref}
+            type={type}
+            className={cx(
+                'Button',
+                `variant-${variant}`,
+                `size-${size}`,
+                { fullWidth },
+                className
+            )}
+            {...props}>
             {children}
         </button>
     );
-};
+});
+
+Button.displayName = 'Button';
 
 export default Button;

--- a/server/src/client/src/components/shared/Button/Button.tsx
+++ b/server/src/client/src/components/shared/Button/Button.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 interface ButtonProps {
     type?: 'primary' | 'secondary';
+    disabled?: boolean;
     style?: React.CSSProperties;
     children?: React.ReactNode;
     onClick?: () => void;
@@ -13,6 +14,7 @@ interface ButtonProps {
 
 const Button = ({
     type='secondary',
+    disabled,
     style,
     children,
     onClick
@@ -20,6 +22,7 @@ const Button = ({
     return (
         <button
             type="button"
+            disabled={disabled}
             style={style}
             className={cx('Button', type)}
             onClick={onClick}>

--- a/server/src/client/src/components/shared/Card/Card.module.scss
+++ b/server/src/client/src/components/shared/Card/Card.module.scss
@@ -55,15 +55,14 @@
     &.interactive {
         cursor: pointer;
         transition: var.$TRANSITION_FAST;
-        transition-property: transform, box-shadow;
+        transition-property: box-shadow, background-color;
 
         &:hover {
-            transform: translateY(-2px);
             box-shadow: var.$SHADOW_HOVER;
         }
 
         &:active {
-            transform: translateY(-1px) scale(0.99);
+            transform: scale(0.99);
         }
     }
 }

--- a/server/src/client/src/components/shared/EqualizerPreset/EqualizerPreset.module.scss
+++ b/server/src/client/src/components/shared/EqualizerPreset/EqualizerPreset.module.scss
@@ -25,8 +25,6 @@
   
   &:hover {
     background-color: var(--b-color-hover, rgba(var(--b-color-hover-rgb, 0, 0, 0), 0.05));
-    transform: translateY(-1px);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   }
   
   &.active {
@@ -70,8 +68,6 @@
   
   &:hover {
     opacity: 0.9;
-    transform: translateY(-1px);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }
 }
 

--- a/server/src/client/src/components/shared/EqualizerSlider/EqualizerSlider.module.scss
+++ b/server/src/client/src/components/shared/EqualizerSlider/EqualizerSlider.module.scss
@@ -55,7 +55,6 @@
 
     &:hover {
       background: var(--b-color-point);
-      transform: scale(1.1);
     }
   }
 
@@ -71,7 +70,6 @@
 
     &:hover {
       background: var(--b-color-point);
-      transform: scale(1.1);
     }
   }
 
@@ -87,7 +85,6 @@
 
     &:hover {
       background: var(--b-color-point);
-      transform: scale(1.1);
     }
   }
 }

--- a/server/src/client/src/components/shared/Loading/Loading.module.scss
+++ b/server/src/client/src/components/shared/Loading/Loading.module.scss
@@ -17,25 +17,25 @@
         0% {
             height: 6px;
             transform: translateY(0px);
-            background: #ff8e3a;
+            background: rgba(114, 215, 230, 0.6);
         }
-    
+
         25% {
             height: 20px;
             transform: translateY(-5px) scaleY(1.7);
-            background: #ed509e;
+            background: rgba(114, 215, 230, 1);
         }
-    
+
         50% {
             height: 6px;
             transform: translateY(0px);
-            background: #9c73f8;
+            background: rgba(56, 187, 210, 0.8);
         }
-    
+
         100% {
             height: 6px;
             transform: translateY(0px);
-            background: #0fccce;
+            background: rgba(114, 215, 230, 0.6);
         }
     }
     
@@ -54,7 +54,7 @@
         width: 0.6rem;
         height: 0.4rem;
         border-radius: 0.5rem;
-        background: orange;
+        background: rgba(114, 215, 230, 0.6);
         animation: audio-wave 2.2s infinite ease-in-out;
     }
     

--- a/server/src/client/src/components/shared/PanelContent.module.scss
+++ b/server/src/client/src/components/shared/PanelContent.module.scss
@@ -38,13 +38,13 @@
 
     :global(.panel-sub-title) {
         margin-bottom: 0.25rem;
-        font-size: 0.875rem;
+        font-size: var.$TEXT_SIZE_SM;
         color: var.$COLOR_TEXT_MUTED;
     }
 
     :global(.panel-sub-content) {
-        font-size: 0.875rem;
-        font-weight: 700;
+        font-size: var.$TEXT_SIZE_SM;
+        font-weight: var.$FONT_WEIGHT_BOLD;
     }
 
     :global(.items) {
@@ -83,7 +83,7 @@
         align-items: center;
         gap: 0.5rem;
         padding: 1rem 0 0;
-        font-size: 0.8rem;
+        font-size: var.$TEXT_SIZE_SM;
         color: var.$COLOR_TEXT_MUTED;
     }
 }

--- a/server/src/client/src/components/shared/SearchField/SearchField.module.scss
+++ b/server/src/client/src/components/shared/SearchField/SearchField.module.scss
@@ -4,7 +4,7 @@
     flex: 1 1 18rem;
     min-width: min(100%, 16rem);
     max-width: 28rem;
-    min-height: 44px;
+    min-height: var.$CONTROL_HEIGHT_MD;
     padding: 0.25rem;
     display: flex;
     align-items: center;
@@ -36,7 +36,7 @@
     background: transparent;
     color: var.$COLOR_TEXT;
     font: inherit;
-    font-size: 0.875rem;
+    font-size: var.$TEXT_SIZE_SM;
 
     &::placeholder {
         color: var.$COLOR_TEXT_MUTED;

--- a/server/src/client/src/components/shared/SearchField/SearchField.module.scss
+++ b/server/src/client/src/components/shared/SearchField/SearchField.module.scss
@@ -4,28 +4,20 @@
     flex: 1 1 18rem;
     min-width: min(100%, 16rem);
     max-width: 28rem;
-    min-height: 48px;
+    min-height: 44px;
     padding: 0.25rem;
     display: flex;
     align-items: center;
     gap: 0.5rem;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
     border-radius: var.$RADIUS_FULL;
-    background:
-        linear-gradient(180deg, rgba(10, 36, 45, 0.82) 0%, rgba(7, 27, 35, 0.92) 100%);
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.04),
-        0 12px 24px rgba(2, 8, 11, 0.12);
+    background: rgba(10, 36, 45, 0.7);
     transition: var.$TRANSITION_FAST;
-    transition-property: border-color, box-shadow, background-color;
+    transition-property: border-color, background-color, box-shadow;
 
     &:focus-within {
         border-color: var.$COLOR_FOCUS;
-        background:
-            linear-gradient(180deg, rgba(12, 42, 53, 0.88) 0%, rgba(8, 31, 39, 0.96) 100%);
-        box-shadow:
-            0 0 0 3px rgba(114, 215, 230, 0.14),
-            0 16px 28px rgba(2, 8, 11, 0.16);
+        box-shadow: 0 0 0 3px rgba(114, 215, 230, 0.14);
     }
 }
 
@@ -56,18 +48,18 @@
 }
 
 .clearButton {
-    width: 36px;
-    height: 36px;
-    margin-right: 0.125rem;
+    width: 32px;
+    height: 32px;
+    margin-right: 0.25rem;
     border: 0;
     border-radius: var.$RADIUS_FULL;
-    background: rgba(255, 255, 255, 0.04);
+    background: transparent;
     color: var.$COLOR_TEXT_SECONDARY;
     display: flex;
     align-items: center;
     justify-content: center;
     transition: var.$TRANSITION_FAST;
-    transition-property: color, background-color, transform;
+    transition-property: color, background-color;
 
     svg {
         width: 0.875rem;
@@ -76,12 +68,7 @@
 
     &:hover {
         color: var.$COLOR_TEXT;
-        background: rgba(255, 255, 255, 0.08);
-        transform: translateY(-1px);
-    }
-
-    &:active {
-        transform: translateY(0);
+        background: rgba(255, 255, 255, 0.06);
     }
 }
 

--- a/server/src/client/src/components/shared/Select.module.scss
+++ b/server/src/client/src/components/shared/Select.module.scss
@@ -3,15 +3,15 @@
 .trigger {
     width: min(100%, 20rem);
     min-width: 14rem;
-    min-height: 44px;
+    min-height: var.$CONTROL_HEIGHT_MD;
     padding: 0.625rem 0.875rem 0.625rem 1rem;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
     border-radius: var.$RADIUS_LG;
     background: rgba(10, 36, 45, 0.7);
     color: var.$COLOR_TEXT;
     font: inherit;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var.$TEXT_SIZE_SM;
+    font-weight: var.$FONT_WEIGHT_MEDIUM;
     display: inline-flex;
     align-items: center;
     justify-content: space-between;
@@ -66,12 +66,12 @@
 
 .item {
     position: relative;
-    min-height: 44px;
+    min-height: var.$CONTROL_HEIGHT_MD;
     padding: 0.75rem 2.5rem 0.75rem 0.875rem;
     border-radius: 0.75rem;
     color: var.$COLOR_TEXT;
-    font-size: 0.875rem;
-    line-height: 1.45;
+    font-size: var.$TEXT_SIZE_SM;
+    line-height: var.$LINE_HEIGHT_DEFAULT;
     display: flex;
     align-items: center;
     transition: var.$TRANSITION_FAST;

--- a/server/src/client/src/components/shared/Select.module.scss
+++ b/server/src/client/src/components/shared/Select.module.scss
@@ -3,12 +3,11 @@
 .trigger {
     width: min(100%, 20rem);
     min-width: 14rem;
-    min-height: 48px;
-    padding: 0.75rem 0.875rem 0.75rem 1rem;
+    min-height: 44px;
+    padding: 0.625rem 0.875rem 0.625rem 1rem;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
-    border-radius: 1rem;
-    background:
-        linear-gradient(180deg, rgba(10, 36, 45, 0.86) 0%, rgba(7, 27, 35, 0.92) 100%);
+    border-radius: var.$RADIUS_LG;
+    background: rgba(10, 36, 45, 0.7);
     color: var.$COLOR_TEXT;
     font: inherit;
     font-size: 0.875rem;
@@ -17,32 +16,23 @@
     align-items: center;
     justify-content: space-between;
     gap: 0.875rem;
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.04),
-        0 12px 24px rgba(2, 8, 11, 0.12);
     transition: var.$TRANSITION_FAST;
-    transition-property: border-color, box-shadow, background-color, transform;
+    transition-property: border-color, background-color;
 
     &:hover {
         border-color: var.$COLOR_BORDER;
-        background:
-            linear-gradient(180deg, rgba(12, 44, 55, 0.9) 0%, rgba(9, 33, 42, 0.96) 100%);
-        transform: translateY(-1px);
+        background: rgba(12, 44, 55, 0.8);
     }
 
     &:focus-visible {
         outline: none;
         border-color: var.$COLOR_FOCUS;
-        box-shadow:
-            0 0 0 3px rgba(114, 215, 230, 0.14),
-            0 16px 28px rgba(2, 8, 11, 0.16);
+        box-shadow: 0 0 0 3px rgba(114, 215, 230, 0.14);
     }
 
     &[data-state='open'] {
         border-color: var.$COLOR_BORDER;
-        background:
-            linear-gradient(180deg, rgba(12, 44, 55, 0.92) 0%, rgba(9, 33, 42, 0.98) 100%);
-        transform: translateY(-1px);
+        background: rgba(12, 44, 55, 0.8);
     }
 }
 
@@ -62,10 +52,9 @@
     max-height: min(18rem, var(--radix-select-content-available-height));
     overflow: hidden;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
-    border-radius: 1rem;
-    background:
-        linear-gradient(180deg, rgba(8, 28, 36, 0.98) 0%, rgba(5, 20, 28, 0.98) 100%);
-    box-shadow: var.$SHADOW_MAIN;
+    border-radius: var.$RADIUS_LG;
+    background: rgba(8, 28, 36, 0.98);
+    box-shadow: var.$SHADOW_SUB;
     color: var.$COLOR_TEXT;
     z-index: 40;
     animation: select-in 140ms ease;

--- a/server/src/client/src/components/shared/SettingSection/SettingSection.module.scss
+++ b/server/src/client/src/components/shared/SettingSection/SettingSection.module.scss
@@ -13,41 +13,34 @@
 
 .sectionHeader {
     margin-bottom: var.$SPACING_LG;
+}
 
-    h3 {
-        font-size: 1.0625rem;
-        font-weight: 600;
-        margin: 0;
-        margin-bottom: var.$SPACING_MD;
-        padding-bottom: var.$SPACING_MD;
-        border-bottom: 1px solid var.$COLOR_BORDER;
-        color: var.$COLOR_TEXT;
-        display: flex;
-        align-items: center;
-        gap: var.$SPACING_SM;
-    }
+.sectionTitle {
+    margin-bottom: var.$SPACING_MD;
+    padding-bottom: var.$SPACING_MD;
+    border-bottom: 1px solid var.$COLOR_BORDER;
+    display: flex;
+    align-items: center;
+    gap: var.$SPACING_SM;
+}
 
-    .sectionIcon {
-        width: 28px;
-        height: 28px;
-        border-radius: 999px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: var.$COLOR_POINT;
+.sectionIcon {
+    width: 28px;
+    height: 28px;
+    border-radius: 999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var.$COLOR_POINT;
 
-        svg {
-            width: 16px;
-            height: 16px;
-        }
+    svg {
+        width: 16px;
+        height: 16px;
     }
 }
 
 .sectionDescription {
-    font-size: 0.9375rem;
-    line-height: 1.6;
-    color: var.$COLOR_TEXT_SECONDARY;
-    margin: 0;
+    line-height: var.$LINE_HEIGHT_RELAXED;
 }
 
 .sectionContent {
@@ -79,18 +72,12 @@
 }
 
 .settingItemHeader {
-    h4 {
-        font-size: 0.9375rem;
-        font-weight: 600;
-        margin: 0 0 var.$SPACING_XS;
-        color: var.$COLOR_TEXT;
-    }
+.settingItemTitle {
+    margin-bottom: var.$SPACING_XS;
+}
 
     .description {
-        font-size: 0.8125rem;
-        color: var.$COLOR_TEXT_TERTIARY;
-        margin: 0;
-        line-height: 1.5;
+        line-height: var.$LINE_HEIGHT_DEFAULT;
     }
 }
 
@@ -113,8 +100,8 @@
 
     p {
         margin: 0;
-        font-size: 0.875rem;
-        line-height: 1.6;
+        font-size: var.$TEXT_SIZE_SM;
+        line-height: var.$LINE_HEIGHT_RELAXED;
         color: var.$COLOR_TEXT_SECONDARY;
     }
 

--- a/server/src/client/src/components/shared/SettingSection/SettingSection.module.scss
+++ b/server/src/client/src/components/shared/SettingSection/SettingSection.module.scss
@@ -1,14 +1,10 @@
 @use '~/styles/var';
 
 .settingSection {
-    background:
-        linear-gradient(180deg, rgba(9, 32, 41, 0.86) 0%, rgba(7, 25, 32, 0.82) 100%);
-    border-radius: var.$RADIUS_XL;
+    background: rgba(8, 28, 36, 0.6);
+    border-radius: var.$RADIUS_LG;
     padding: var.$SPACING_LG;
-    margin-bottom: var.$SPACING_2XL;
-    box-shadow: var.$SHADOW_MAIN;
     border: 1px solid var.$COLOR_BORDER_SUBTLE;
-    backdrop-filter: blur(18px);
 
     @media (max-width: 768px) {
         padding: var.$SPACING_MD;
@@ -32,16 +28,13 @@
     }
 
     .sectionIcon {
-        width: 32px;
-        height: 32px;
+        width: 28px;
+        height: 28px;
         border-radius: 999px;
         display: flex;
         align-items: center;
         justify-content: center;
-        background:
-            linear-gradient(135deg, rgba(193, 244, 251, 0.16) 0%, rgba(114, 215, 230, 0.08) 100%);
         color: var.$COLOR_POINT;
-        border: 1px solid rgba(193, 244, 251, 0.12);
 
         svg {
             width: 16px;
@@ -65,17 +58,11 @@
 
 .settingItem {
     padding: var.$SPACING_MD;
-    border-radius: var.$RADIUS_XL;
-    background:
-        linear-gradient(180deg, rgba(12, 42, 52, 0.84) 0%, rgba(10, 31, 40, 0.9) 100%);
-    border: 1px solid rgba(193, 244, 251, 0.08);
-    transition: var.$TRANSITION_FAST;
-    transition-property: background-color, box-shadow, border-color, transform;
+    border-radius: var.$RADIUS_MD;
+    border-bottom: 1px solid var.$COLOR_BORDER_SUBTLE;
 
-    &:hover {
-        border-color: rgba(193, 244, 251, 0.14);
-        box-shadow: var.$SHADOW_SUB;
-        transform: translateY(-1px);
+    &:last-child {
+        border-bottom: none;
     }
 }
 

--- a/server/src/client/src/components/shared/SettingSection/SettingSection.tsx
+++ b/server/src/client/src/components/shared/SettingSection/SettingSection.tsx
@@ -41,10 +41,10 @@ export const SettingSection = ({ title, description, icon, children }: SettingSe
     return (
         <section className={styles.settingSection}>
             <div className={styles.sectionHeader}>
-                <h3>
+                <Text as="h3" size="lg" weight="semibold" className={styles.sectionTitle}>
                     {icon && <span className={styles.sectionIcon}>{icon}</span>}
-                    {title}
-                </h3>
+                    <span>{title}</span>
+                </Text>
                 {description && (
                     <Text as="p" variant="secondary" size="md" className={styles.sectionDescription}>
                         {description}

--- a/server/src/client/src/components/shared/SiteHeader/SiteHeader.module.scss
+++ b/server/src/client/src/components/shared/SiteHeader/SiteHeader.module.scss
@@ -79,8 +79,8 @@
     @media (min-width: 1024px) {
         display: block;
         padding: 0 var.$SPACING_SM;
-        font-size: 0.6875rem;
-        font-weight: 600;
+        font-size: var.$TEXT_SIZE_XS;
+        font-weight: var.$FONT_WEIGHT_SEMIBOLD;
         letter-spacing: 0.1em;
         text-transform: uppercase;
         color: var.$COLOR_TEXT_MUTED;
@@ -91,12 +91,12 @@
     display: flex;
     align-items: center;
     gap: var.$SPACING_SM;
-    min-height: 40px;
+    min-height: var.$CONTROL_HEIGHT_SM;
     padding: 0 var.$SPACING_MD;
     border-radius: var.$RADIUS_FULL;
     text-decoration: none;
-    font-size: 0.875rem;
-    font-weight: 500;
+    font-size: var.$TEXT_SIZE_SM;
+    font-weight: var.$FONT_WEIGHT_MEDIUM;
     color: var.$COLOR_TEXT_SECONDARY;
     transition: var.$TRANSITION_FAST;
     transition-property: color, background-color;

--- a/server/src/client/src/components/shared/SiteHeader/SiteHeader.module.scss
+++ b/server/src/client/src/components/shared/SiteHeader/SiteHeader.module.scss
@@ -6,11 +6,9 @@
     flex-direction: column;
     gap: var.$SPACING_SM;
     padding: 0.75rem;
-    background:
-        linear-gradient(180deg, rgba(6, 24, 32, 0.92) 0%, rgba(5, 20, 28, 0.82) 100%);
+    background: rgba(5, 20, 28, 0.92);
     border-bottom: 1px solid var.$APP_SHELL_BORDER;
-    backdrop-filter: blur(20px);
-    box-shadow: var.$APP_SHELL_SHADOW;
+    backdrop-filter: blur(12px);
 
     @media (min-width: 1024px) {
         height: 100%;
@@ -21,56 +19,6 @@
     }
 }
 
-.brand {
-    position: relative;
-    z-index: 1;
-}
-
-.brandLink {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    text-decoration: none;
-    color: inherit;
-}
-
-.brandIcon {
-    position: relative;
-    width: 40px;
-    height: 40px;
-    border-radius: 14px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--b-gradient-primary);
-    box-shadow:
-        inset 0 1px 0 rgba(255, 255, 255, 0.34),
-        0 10px 20px rgba(20, 100, 120, 0.22);
-
-    &::after {
-        content: '';
-        position: absolute;
-        inset: 1px;
-        border-radius: 13px;
-        border: 1px solid rgba(255, 255, 255, 0.2);
-    }
-
-    svg {
-        width: 18px;
-        height: 18px;
-        color: #03202a;
-        position: relative;
-        z-index: 1;
-    }
-}
-
-.brandName {
-    font-size: 0.9375rem;
-    font-weight: 700;
-    line-height: 1.2;
-    color: var.$COLOR_TEXT;
-    letter-spacing: 0.01em;
-}
 
 .nav {
     position: relative;
@@ -106,7 +54,7 @@
     ul {
         display: flex;
         align-items: center;
-        gap: var.$SPACING_XS;
+        gap: 2px;
         list-style: none;
         margin: 0;
         padding: 0;
@@ -132,8 +80,8 @@
         display: block;
         padding: 0 var.$SPACING_SM;
         font-size: 0.6875rem;
-        font-weight: 700;
-        letter-spacing: 0.16em;
+        font-weight: 600;
+        letter-spacing: 0.1em;
         text-transform: uppercase;
         color: var.$COLOR_TEXT_MUTED;
     }
@@ -143,17 +91,15 @@
     display: flex;
     align-items: center;
     gap: var.$SPACING_SM;
-    min-height: 44px;
+    min-height: 40px;
     padding: 0 var.$SPACING_MD;
     border-radius: var.$RADIUS_FULL;
-    border: 1px solid transparent;
     text-decoration: none;
     font-size: 0.875rem;
     font-weight: 500;
     color: var.$COLOR_TEXT_SECONDARY;
-    background: rgba(239, 248, 251, 0.03);
     transition: var.$TRANSITION_FAST;
-    transition-property: color, background-color, border-color, transform, box-shadow;
+    transition-property: color, background-color;
 
     svg {
         width: 18px;
@@ -164,18 +110,11 @@
     &:hover {
         color: var.$COLOR_TEXT;
         background-color: rgba(239, 248, 251, 0.06);
-        border-color: var.$COLOR_BORDER_SUBTLE;
-        transform: translateY(-1px);
     }
 
     &.active {
         color: var.$COLOR_TEXT;
-        background:
-            linear-gradient(135deg, rgba(185, 244, 251, 0.14) 0%, rgba(113, 215, 230, 0.08) 100%);
-        border-color: rgba(185, 244, 251, 0.18);
-        box-shadow:
-            inset 0 1px 0 rgba(255, 255, 255, 0.08),
-            0 10px 24px rgba(3, 18, 24, 0.24);
+        background: rgba(185, 244, 251, 0.1);
     }
 }
 

--- a/server/src/client/src/components/shared/SiteHeader/SiteHeader.tsx
+++ b/server/src/client/src/components/shared/SiteHeader/SiteHeader.tsx
@@ -2,7 +2,6 @@ import styles from './SiteHeader.module.scss';
 import { useEffect, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
-import { Music } from '~/icon';
 import { appShell } from '~/config/app-shell';
 
 const NAVIGATION_GROUPS = [
@@ -51,14 +50,6 @@ export default function SiteHeader() {
 
     return (
         <header className={styles.header}>
-            <div className={styles.brand}>
-                <Link to="/" className={styles.brandLink}>
-                    <div className={styles.brandIcon}>
-                        <Music />
-                    </div>
-                    <span className={styles.brandName}>{appShell.brand.name}</span>
-                </Link>
-            </div>
             <nav ref={ref} className={styles.nav} aria-label={`${appShell.brand.name} navigation`}>
                 {NAVIGATION_GROUPS.map((group) => (
                     <div

--- a/server/src/client/src/components/shared/StickyHeader/StickyHeader.module.scss
+++ b/server/src/client/src/components/shared/StickyHeader/StickyHeader.module.scss
@@ -12,5 +12,5 @@
     z-index: 5;
     background:
         linear-gradient(180deg, rgba(4, 18, 24, 0.95) 0%, rgba(4, 18, 24, 0.82) 72%, rgba(4, 18, 24, 0) 100%);
-    backdrop-filter: blur(18px);
+    backdrop-filter: blur(8px);
 }

--- a/server/src/client/src/components/shared/SubPageHeader/SubPageHeader.module.scss
+++ b/server/src/client/src/components/shared/SubPageHeader/SubPageHeader.module.scss
@@ -7,8 +7,6 @@
     padding: 0 1rem;
     height: 56px;
     background-color: var.$COLOR_BACKGROUND_LAYER_1;
-    font-size: 1rem;
-    font-weight: 700;
     border-bottom: 1px solid var.$COLOR_BORDER;
 
     @media (min-width: 1024px) {
@@ -29,8 +27,6 @@
 
         .back-text {
             display: none;
-            font-size: 0.875rem;
-            font-weight: 500;
             margin-left: 0.5rem;
 
             @media (min-width: 1024px) {

--- a/server/src/client/src/components/shared/SubPageHeader/SubPageHeader.module.scss
+++ b/server/src/client/src/components/shared/SubPageHeader/SubPageHeader.module.scss
@@ -5,13 +5,13 @@
     justify-content: space-between;
     align-items: center;
     padding: 0 1rem;
-    height: 60px;
+    height: 56px;
     background-color: var.$COLOR_BACKGROUND_LAYER_1;
-    font-size: 1.2rem;
-    font-weight: bold;
+    font-size: 1rem;
+    font-weight: 700;
     border-bottom: 1px solid var.$COLOR_BORDER;
 
-    @media (min-width: var.$BREAKPOINT_DESKTOP) {
+    @media (min-width: 1024px) {
         height: 100%;
         border-right: 1px solid var.$COLOR_BORDER;
         border-bottom: none;
@@ -29,7 +29,8 @@
 
         .back-text {
             display: none;
-            font-size: 1rem;
+            font-size: 0.875rem;
+            font-weight: 500;
             margin-left: 0.5rem;
 
             @media (min-width: 1024px) {

--- a/server/src/client/src/components/shared/SubPageHeader/SubPageHeader.tsx
+++ b/server/src/client/src/components/shared/SubPageHeader/SubPageHeader.tsx
@@ -1,6 +1,7 @@
 import styles from './SubPageHeader.module.scss';
 import classNames from 'classnames/bind';
 import { useBack } from '~/hooks';
+import Text from '../Text';
 const cx = classNames.bind(styles);
 
 import { ChevronLeft } from '~/icon';
@@ -10,8 +11,11 @@ const SubPageHeader = () => {
 
     return (
         <div className={cx('SubPageHeader')}>
-            <button onClick={back}>
-                <ChevronLeft /> <span className={cx('back-text')}>Back</span>
+            <button type="button" onClick={back}>
+                <ChevronLeft />
+                <Text as="span" size="sm" weight="medium" className={cx('back-text')}>
+                    Back
+                </Text>
             </button>
         </div>
     );

--- a/server/src/client/src/components/shared/SummaryTitle/SummaryTitle.module.scss
+++ b/server/src/client/src/components/shared/SummaryTitle/SummaryTitle.module.scss
@@ -2,5 +2,5 @@
     max-width: 450px;
     text-align: center;
     font-size: 1.25rem;
-    font-weight: bold;
+    font-weight: 700;
 }

--- a/server/src/client/src/components/shared/SummaryTitle/SummaryTitle.module.scss
+++ b/server/src/client/src/components/shared/SummaryTitle/SummaryTitle.module.scss
@@ -1,6 +1,4 @@
 .SummaryTitle {
     max-width: 450px;
     text-align: center;
-    font-size: 1.25rem;
-    font-weight: 700;
 }

--- a/server/src/client/src/components/shared/SummaryTitle/SummaryTitle.tsx
+++ b/server/src/client/src/components/shared/SummaryTitle/SummaryTitle.tsx
@@ -3,14 +3,24 @@ import classNames from 'classnames/bind';
 const cx = classNames.bind(styles);
 
 import React from 'react';
+import Text, { type TextElement } from '../Text';
 
 interface SummaryTitleProps {
-    as?: React.ElementType;
+    as?: TextElement;
+    className?: string;
     children?: React.ReactNode;
 }
 
-const SummaryTitle = ({ as = 'div', children }: SummaryTitleProps) => {
-    return React.createElement(as, { className: cx('SummaryTitle') }, children);
+const SummaryTitle = ({ as = 'div', className, children }: SummaryTitleProps) => {
+    return (
+        <Text
+            as={as}
+            size="title"
+            weight="bold"
+            className={cx('SummaryTitle', className)}>
+            {children}
+        </Text>
+    );
 };
 
 export default SummaryTitle;

--- a/server/src/client/src/components/shared/Text/Text.module.scss
+++ b/server/src/client/src/components/shared/Text/Text.module.scss
@@ -3,7 +3,7 @@
 .Text {
     margin: 0;
     padding: 0;
-    line-height: 1.45;
+    line-height: var.$LINE_HEIGHT_DEFAULT;
 
     &.variant-primary {
         color: var.$COLOR_TEXT;
@@ -22,45 +22,54 @@
     }
 
     &.size-xs {
-        font-size: 0.6875rem;
+        font-size: var.$TEXT_SIZE_XS;
     }
 
     &.size-sm {
-        font-size: 0.8125rem;
+        font-size: var.$TEXT_SIZE_SM;
     }
 
     &.size-md {
-        font-size: 0.9375rem;
+        font-size: var.$TEXT_SIZE_MD;
+    }
+
+    &.size-base {
+        font-size: var.$TEXT_SIZE_BASE;
     }
 
     &.size-lg {
-        font-size: 1.0625rem;
+        font-size: var.$TEXT_SIZE_LG;
+    }
+
+    &.size-title {
+        font-size: var.$TEXT_SIZE_TITLE;
+        line-height: var.$LINE_HEIGHT_HEADING;
     }
 
     &.size-xl {
-        font-size: 1.375rem;
-        line-height: 1.25;
+        font-size: var.$TEXT_SIZE_XL;
+        line-height: var.$LINE_HEIGHT_HEADING;
     }
 
     &.size-2xl {
-        font-size: clamp(1.75rem, 2vw, 2.125rem);
-        line-height: 1.12;
+        font-size: var.$TEXT_SIZE_2XL;
+        line-height: var.$LINE_HEIGHT_DISPLAY;
     }
 
     &.weight-normal {
-        font-weight: 400;
+        font-weight: var.$FONT_WEIGHT_NORMAL;
     }
 
     &.weight-medium {
-        font-weight: 500;
+        font-weight: var.$FONT_WEIGHT_MEDIUM;
     }
 
     &.weight-semibold {
-        font-weight: 600;
+        font-weight: var.$FONT_WEIGHT_SEMIBOLD;
     }
 
     &.weight-bold {
-        font-weight: 700;
+        font-weight: var.$FONT_WEIGHT_BOLD;
     }
 
     &.truncate {

--- a/server/src/client/src/components/shared/Text/Text.tsx
+++ b/server/src/client/src/components/shared/Text/Text.tsx
@@ -2,10 +2,10 @@ import styles from './Text.module.scss';
 import classNames from 'classnames/bind';
 const cx = classNames.bind(styles);
 
-type TextElement = 'span' | 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div';
-type TextVariant = 'primary' | 'secondary' | 'tertiary' | 'muted';
-type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
-type TextWeight = 'normal' | 'medium' | 'semibold' | 'bold';
+export type TextElement = 'span' | 'p' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div';
+export type TextVariant = 'primary' | 'secondary' | 'tertiary' | 'muted';
+export type TextSize = 'xs' | 'sm' | 'md' | 'base' | 'lg' | 'title' | 'xl' | '2xl';
+export type TextWeight = 'normal' | 'medium' | 'semibold' | 'bold';
 
 interface TextProps {
     as?: TextElement;

--- a/server/src/client/src/components/shared/Text/index.ts
+++ b/server/src/client/src/components/shared/Text/index.ts
@@ -1,1 +1,7 @@
 export { default } from './Text';
+export type {
+    TextElement,
+    TextSize,
+    TextVariant,
+    TextWeight
+} from './Text';

--- a/server/src/client/src/components/shared/Toggle/Toggle.module.scss
+++ b/server/src/client/src/components/shared/Toggle/Toggle.module.scss
@@ -1,37 +1,46 @@
+@use '~/styles/var';
+
 .Toggle {
-    display: flex;
+    display: inline-flex;
     align-items: center;
+    gap: 0.625rem;
     cursor: pointer;
 }
 
 .ToggleSwitch {
-    width: 50px;
-    height: 24px;
-    background-color: #ccc;
-    border-radius: 12px;
     position: relative;
-    transition: background-color 0.3s;
-}
+    width: 44px;
+    height: 24px;
+    border-radius: var.$RADIUS_FULL;
+    background: rgba(239, 248, 251, 0.12);
+    border: 1px solid var.$COLOR_BORDER_SUBTLE;
+    transition: background-color 200ms ease, border-color 200ms ease;
+    flex-shrink: 0;
 
-.is-toggled {
-    background-color: #4caf50;
+    &.is-toggled {
+        background: var(--b-gradient-primary);
+        border-color: transparent;
+    }
 }
 
 .ToggleKnob {
-    width: 20px;
-    height: 20px;
-    background-color: white;
-    border-radius: 50%;
     position: absolute;
     top: 2px;
     left: 2px;
-    transition: transform 0.3s;
-}
+    width: 18px;
+    height: 18px;
+    border-radius: var.$RADIUS_FULL;
+    background: var.$COLOR_TEXT_SECONDARY;
+    box-shadow: 0 1px 3px rgba(2, 8, 11, 0.3);
+    transition: transform 200ms ease, background-color 200ms ease;
 
-.is-toggled .ToggleKnob {
-    transform: translateX(26px);
+    .is-toggled & {
+        transform: translateX(20px);
+        background: #03212b;
+    }
 }
 
 .ToggleLabel {
-    margin-left: 10px;
+    font-size: 0.875rem;
+    color: var.$COLOR_TEXT_SECONDARY;
 }

--- a/server/src/client/src/components/shared/Toggle/Toggle.module.scss
+++ b/server/src/client/src/components/shared/Toggle/Toggle.module.scss
@@ -4,7 +4,24 @@
     display: inline-flex;
     align-items: center;
     gap: 0.625rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
     cursor: pointer;
+
+    &:focus-visible {
+        outline: none;
+
+        .ToggleSwitch {
+            box-shadow: 0 0 0 3px rgba(114, 215, 230, 0.14);
+            border-color: var.$COLOR_FOCUS;
+        }
+    }
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
 }
 
 .ToggleSwitch {
@@ -41,6 +58,5 @@
 }
 
 .ToggleLabel {
-    font-size: 0.875rem;
     color: var.$COLOR_TEXT_SECONDARY;
 }

--- a/server/src/client/src/components/shared/Toggle/Toggle.tsx
+++ b/server/src/client/src/components/shared/Toggle/Toggle.tsx
@@ -1,6 +1,7 @@
 import styles from './Toggle.module.scss';
 import classNames from 'classnames/bind';
 import React from 'react';
+import Text from '../Text';
 
 const cx = classNames.bind(styles);
 
@@ -8,20 +9,42 @@ interface ToggleProps {
     value: boolean;
     onChange: (value: boolean) => void;
     children?: React.ReactNode;
+    ariaLabel?: string;
+    disabled?: boolean;
+    className?: string;
 }
 
-const Toggle = ({ value, onChange, children }: ToggleProps) => {    const handleToggle = () => {
-    onChange(!value);
-};
-
-return (
-    <div className={cx('Toggle')} onClick={handleToggle}>
-        <div className={cx('ToggleSwitch', { 'is-toggled': value })}>
-            <div className={cx('ToggleKnob')} />
-        </div>
-        {children && <span className={cx('ToggleLabel')}>{children}</span>}
-    </div>
-);
+const Toggle = ({
+    value,
+    onChange,
+    children,
+    ariaLabel,
+    disabled = false,
+    className
+}: ToggleProps) => {
+    return (
+        <button
+            type="button"
+            role="switch"
+            aria-checked={value}
+            aria-label={ariaLabel}
+            disabled={disabled}
+            className={cx('Toggle', { disabled }, className)}
+            onClick={() => onChange(!value)}>
+            <span className={cx('ToggleSwitch', { 'is-toggled': value })}>
+                <span className={cx('ToggleKnob')} />
+            </span>
+            {children && (
+                <Text
+                    as="span"
+                    variant="secondary"
+                    size="sm"
+                    className={cx('ToggleLabel')}>
+                    {children}
+                </Text>
+            )}
+        </button>
+    );
 };
 
 export default Toggle;

--- a/server/src/client/src/pages/Equalizer.module.scss
+++ b/server/src/client/src/pages/Equalizer.module.scss
@@ -12,7 +12,7 @@
 
 .title {
   font-size: 1.8rem;
-  font-weight: bold;
+  font-weight: 700;
   margin-bottom: 0.5rem;
   color: var(--b-color-text);
 }
@@ -97,7 +97,6 @@
 
     &:hover {
       background: var(--b-color-point);
-      transform: scale(1.1);
     }
   }
 
@@ -113,7 +112,6 @@
 
     &:hover {
       background: var(--b-color-point);
-      transform: scale(1.1);
     }
   }
 
@@ -129,7 +127,6 @@
 
     &:hover {
       background: var(--b-color-point);
-      transform: scale(1.1);
     }
   }
 }
@@ -153,7 +150,6 @@
   
   &:hover {
     background-color: var(--b-color-hover, rgba(var(--b-color-hover-rgb, 0, 0, 0), 0.05));
-    transform: translateY(-1px);
   }
   
   &.active {

--- a/server/src/client/src/pages/Player.module.scss
+++ b/server/src/client/src/pages/Player.module.scss
@@ -208,7 +208,7 @@
         align-items: center;
         justify-content: center;
         transition: var.$TRANSITION_FAST;
-        transition-property: color, background-color, transform;
+        transition-property: color, background-color;
 
         svg {
             width: 1.25rem;
@@ -218,11 +218,6 @@
         &:hover {
             color: var.$COLOR_TEXT;
             background: rgba(238, 249, 252, 0.08);
-            transform: translateY(-1px);
-        }
-
-        &:active {
-            transform: translateY(0);
         }
 
         &.active {

--- a/server/src/client/src/pages/Setting/Setting.module.scss
+++ b/server/src/client/src/pages/Setting/Setting.module.scss
@@ -1,7 +1,7 @@
 @use '~/styles/var';
 
 .container {
-    width: min(1180px, 100%);
+    width: min(720px, 100%);
     margin: 0 auto;
     padding: clamp(20px, 3vw, 36px);
     color: var.$COLOR_TEXT;
@@ -26,14 +26,17 @@
     }
 }
 
-.settingsGrid {
-    display: grid;
-    grid-template-columns: 280px minmax(0, 1fr);
+.settingsContent {
+    display: flex;
+    flex-direction: column;
     gap: var.$SPACING_LG;
+}
 
-    @media (max-width: 768px) {
-        grid-template-columns: 1fr;
-    }
+.poweredBy {
+    margin: var.$SPACING_2XL 0 0;
+    font-size: 0.75rem;
+    color: var.$COLOR_TEXT_MUTED;
+    text-align: center;
 }
 
 @media (max-width: 768px) {
@@ -43,91 +46,6 @@
 
         p {
             display: none;
-        }
-    }
-}
-
-.settingsNav {
-    position: sticky;
-    top: var.$SPACING_LG;
-    height: fit-content;
-
-    @media (max-width: 768px) {
-        position: relative;
-        margin-bottom: var.$SPACING_LG;
-    }
-
-    ul {
-        list-style: none;
-        padding: var.$SPACING_SM;
-        margin: 0;
-        border-radius: var.$RADIUS_XL;
-        background:
-            linear-gradient(180deg, rgba(8, 28, 36, 0.84) 0%, rgba(7, 24, 31, 0.8) 100%);
-        box-shadow: var.$SHADOW_MAIN;
-        border: 1px solid rgba(193, 244, 251, 0.1);
-
-        @media (max-width: 768px) {
-            display: grid;
-            grid-template-columns: repeat(2, minmax(0, 1fr));
-            gap: var.$SPACING_XS;
-        }
-
-        button {
-            width: 100%;
-            text-align: left;
-            padding: 0.875rem 1rem;
-            border: 1px solid transparent;
-            border-radius: 18px;
-            background: transparent;
-            font-size: 0.9375rem;
-            cursor: pointer;
-            color: var.$COLOR_TEXT_SECONDARY;
-            display: flex;
-            align-items: center;
-            gap: var.$SPACING_MD;
-            transition: var.$TRANSITION_FAST;
-            transition-property: background-color, color, border-color, transform;
-
-            &:hover {
-                background-color: rgba(239, 248, 251, 0.05);
-                color: var.$COLOR_TEXT;
-                border-color: rgba(193, 244, 251, 0.12);
-                transform: translateY(-1px);
-            }
-
-            &.active {
-                background:
-                    linear-gradient(135deg, rgba(193, 244, 251, 0.14) 0%, rgba(114, 215, 230, 0.08) 100%);
-                color: var.$COLOR_TEXT;
-                border-color: rgba(193, 244, 251, 0.16);
-                box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-
-                svg {
-                    color: var.$COLOR_POINT;
-                }
-            }
-
-            svg {
-                width: 18px;
-                height: 18px;
-                flex-shrink: 0;
-                transition: var.$TRANSITION_FAST;
-                transition-property: transform, color;
-            }
-        }
-    }
-}
-
-.settingsContent {
-    min-width: 0;
-
-    .settingSection {
-        margin-bottom: var.$SPACING_2XL;
-        scroll-margin-top: var.$SPACING_LG;
-
-        &:last-child {
-            margin-bottom: 0;
         }
     }
 }

--- a/server/src/client/src/pages/Setting/Setting.tsx
+++ b/server/src/client/src/pages/Setting/Setting.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
 
 import { socket } from '~/socket';
 import { appCopy } from '~/config/copy';
@@ -15,184 +15,13 @@ import {
     TroubleshootingSection
 } from './components';
 import Text from '~/components/shared/Text';
+import { appShell } from '~/config/app-shell';
 
 import styles from './Setting.module.scss';
 
-const SyncIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round">
-        <path d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.57-8.38" />
-    </svg>
-);
-
-const PlayIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round">
-        <polygon points="5 3 19 12 5 21 5 3" />
-    </svg>
-);
-
-const ShieldIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round">
-        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-    </svg>
-);
-
-const AudioIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round">
-        <path d="M3 18v-6a9 9 0 0 1 18 0v6" />
-        <path d="M21 19a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3zM3 19a2 2 0 0 0 2 2h1a2 2 0 0 0 2-2v-3a2 2 0 0 0-2-2H3z" />
-    </svg>
-);
-
-const ThemeIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round">
-        <circle cx="12" cy="12" r="5" />
-        <path d="M12 1v2M12 21v2M4.2 4.2l1.4 1.4M18.4 18.4l1.4 1.4M1 12h2M21 12h2M4.2 19.8l1.4-1.4M18.4 5.6l1.4-1.4" />
-    </svg>
-);
-
-const DevicesIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round">
-        <rect
-            x="2"
-            y="3"
-            width="20"
-            height="14"
-            rx="2"
-            ry="2"
-        />
-        <line x1="8" y1="21" x2="16" y2="21" />
-        <line x1="12" y1="17" x2="12" y2="21" />
-    </svg>
-);
-
-const LabIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round">
-        <path d="M10 2v7.31M14 9.3V2M8.5 2h7M14 9.3a6.5 6.5 0 1 1-4 0" />
-        <path d="M5.58 16.5h12.85" />
-    </svg>
-);
-
-const HelpIcon = () => (
-    <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round">
-        <circle cx="12" cy="12" r="10" />
-        <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-        <line x1="12" y1="17" x2="12.01" y2="17" />
-    </svg>
-);
-
 export default function Setting() {
     const [isStabilityModeEnabled] = useState(Boolean(localStorage.getItem('stability-mode::on')));
-    const [activeSection, setActiveSection] = useState('sync');
     const isAppChannel = Boolean(window.AppChannel);
-    const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({
-        sync: null,
-        play: null,
-        stability: null,
-        audio: null,
-        theme: null,
-        connectors: null,
-        experimental: null,
-        troubleshooting: null
-    });
-
-    const navItems = [
-        {
-            id: 'sync',
-            label: 'Sync',
-            icon: <SyncIcon />
-        },
-        {
-            id: 'play',
-            label: 'Playback',
-            icon: <PlayIcon />
-        },
-        {
-            id: 'audio',
-            label: 'Audio',
-            icon: <AudioIcon />
-        },
-        {
-            id: 'theme',
-            label: 'Appearance',
-            icon: <ThemeIcon />
-        },
-        {
-            id: 'connectors',
-            label: 'Devices',
-            icon: <DevicesIcon />
-        },
-        ...(!isAppChannel ? [{
-            id: 'stability',
-            label: 'Stability',
-            icon: <ShieldIcon />
-        }] : []),
-        {
-            id: 'experimental',
-            label: 'Labs',
-            icon: <LabIcon />
-        },
-        {
-            id: 'troubleshooting',
-            label: 'Support',
-            icon: <HelpIcon />
-        }
-    ];
 
     const handleClickSyncMusic = async (force: boolean) => {
         if (
@@ -208,43 +37,6 @@ export default function Setting() {
         socket.emit('sync-music', { force });
     };
 
-    const scrollToSection = (sectionId: string) => {
-        setActiveSection(sectionId);
-        const sectionElement = sectionRefs.current[sectionId];
-        if (sectionElement) {
-            sectionElement.scrollIntoView({ behavior: 'smooth' });
-        }
-    };
-
-    useEffect(() => {
-        const container = document.querySelector<HTMLElement>('.main-container');
-
-        if (!container) {
-            return;
-        }
-
-        const handleScroll = () => {
-            const containerTop = container.getBoundingClientRect().top;
-            const sections = Object.entries(sectionRefs.current).map(([id, ref]) => ({
-                id,
-                top: Math.abs((ref?.getBoundingClientRect().top || 0) - containerTop - 12)
-            }));
-            const minTop = Math.min(...sections.map(({ top }) => top));
-            const nextSection = sections.find(({ top }) => top === minTop)?.id;
-
-            if (nextSection) {
-                setActiveSection(nextSection);
-            }
-        };
-
-        container.addEventListener('scroll', handleScroll, { passive: true });
-        handleScroll();
-
-        return () => {
-            container.removeEventListener('scroll', handleScroll);
-        };
-    }, []);
-
     return (
         <div className={styles.container}>
             <div className={styles.settingsHeader}>
@@ -256,82 +48,20 @@ export default function Setting() {
                 </Text>
             </div>
 
-            <div className={styles.settingsGrid}>
-                <nav className={styles.settingsNav}>
-                    <ul>
-                        {navItems.map((item) => (
-                            <li key={item.id}>
-                                <button
-                                    className={activeSection === item.id ? styles.active : ''}
-                                    onClick={() => scrollToSection(item.id)}>
-                                    {item.icon}
-                                    {item.label}
-                                </button>
-                            </li>
-                        ))}
-                    </ul>
-                </nav>
-
-                <div className={styles.settingsContent}>
-                    <div
-                        id="section-sync"
-                        ref={(el) => (sectionRefs.current.sync = el)}
-                        className={styles.settingSection}>
-                        <SynchronizationSection onSyncMusic={handleClickSyncMusic} />
-                    </div>
-
-                    <div
-                        id="section-play"
-                        ref={(el) => (sectionRefs.current.play = el)}
-                        className={styles.settingSection}>
-                        <PlayModeSection />
-                    </div>
-
-                    <div
-                        id="section-audio"
-                        ref={(el) => (sectionRefs.current.audio = el)}
-                        className={styles.settingSection}>
-                        <AudioSettingsSection shouldStable={isAppChannel || isStabilityModeEnabled} />
-                    </div>
-
-                    <div
-                        id="section-theme"
-                        ref={(el) => (sectionRefs.current.theme = el)}
-                        className={styles.settingSection}>
-                        <ThemeSection shouldStable={isAppChannel || isStabilityModeEnabled} />
-                    </div>
-
-                    <div
-                        id="section-connectors"
-                        ref={(el) => (sectionRefs.current.connectors = el)}
-                        className={styles.settingSection}>
-                        <ConnectorsSection />
-                    </div>
-
-                    {!isAppChannel && (
-                        <div
-                            id="section-stability"
-                            ref={(el) => (sectionRefs.current.stability = el)}
-                            className={styles.settingSection}>
-                            <StabilityModeSection />
-                        </div>
-                    )}
-
-                    <div
-                        id="section-experimental"
-                        ref={(el) => (sectionRefs.current.experimental = el)}
-                        className={styles.settingSection}>
-                        <ExperimentalSection />
-                    </div>
-
-                    <div
-                        id="section-troubleshooting"
-                        ref={(el) => (sectionRefs.current.troubleshooting = el)}
-                        className={styles.settingSection}>
-                        <TroubleshootingSection />
-                    </div>
-                </div>
+            <div className={styles.settingsContent}>
+                <SynchronizationSection onSyncMusic={handleClickSyncMusic} />
+                <PlayModeSection />
+                <AudioSettingsSection shouldStable={isAppChannel || isStabilityModeEnabled} />
+                <ThemeSection shouldStable={isAppChannel || isStabilityModeEnabled} />
+                <ConnectorsSection />
+                {!isAppChannel && <StabilityModeSection />}
+                <ExperimentalSection />
+                <TroubleshootingSection />
             </div>
+
+            <p className={styles.poweredBy}>
+                Powered by {appShell.brand.name}
+            </p>
         </div>
     );
 }

--- a/server/src/client/src/pages/Setting/components/AudioSettingsSection/AudioSettingsSection.tsx
+++ b/server/src/client/src/pages/Setting/components/AudioSettingsSection/AudioSettingsSection.tsx
@@ -76,6 +76,7 @@ export const AudioSettingsSection = ({ shouldStable }: AudioSettingsSectionProps
                 description="When enabled, plays the original audio files without any transcoding. This provides the highest quality but may use more bandwidth.">
                 <Toggle
                     value={useOriginal}
+                    ariaLabel="Use original audio files"
                     onChange={() => audioSettingsStore.setUseOriginal(!useOriginal)}
                 />
             </SettingItem>

--- a/server/src/client/src/pages/Setting/components/StabilityModeSection/StabilityModeSection.tsx
+++ b/server/src/client/src/pages/Setting/components/StabilityModeSection/StabilityModeSection.tsx
@@ -37,7 +37,11 @@ export const StabilityModeSection = () => {
             <SettingItem
                 title="Enable Stability Mode"
                 description="Activate this to stop using the audio context feature.">
-                <Toggle value={isStabilityModeEnabled} onChange={handleChangeStabilityMode} />
+                <Toggle
+                    value={isStabilityModeEnabled}
+                    ariaLabel="Enable stability mode"
+                    onChange={handleChangeStabilityMode}
+                />
             </SettingItem>
 
             <InfoBox type="warning">

--- a/server/src/client/src/pages/Setting/components/SynchronizationSection/SynchronizationSection.tsx
+++ b/server/src/client/src/pages/Setting/components/SynchronizationSection/SynchronizationSection.tsx
@@ -78,19 +78,13 @@ export const SynchronizationSection = ({ onSyncMusic }: SynchronizationSectionPr
 
                     <div className={styles.buttonContainer}>
                         <Button
-                            onClick={() => handleSync(false)}
-                            style={{
-                                opacity: isSyncing ? 0.5 : 1,
-                                pointerEvents: isSyncing ? 'none' : 'auto'
-                            }}>
+                            disabled={isSyncing}
+                            onClick={() => handleSync(false)}>
                             Sync
                         </Button>
                         <Button
-                            onClick={() => handleSync(true)}
-                            style={{
-                                opacity: isSyncing ? 0.5 : 1,
-                                pointerEvents: isSyncing ? 'none' : 'auto'
-                            }}>
+                            disabled={isSyncing}
+                            onClick={() => handleSync(true)}>
                             Force Sync
                         </Button>
                     </div>

--- a/server/src/client/src/styles/main.scss
+++ b/server/src/client/src/styles/main.scss
@@ -62,7 +62,7 @@ main {
 
     @media (min-width: 1024px) {
         display: grid;
-        grid-template-columns: 320px minmax(0, 1fr);
+        grid-template-columns: 256px minmax(0, 1fr);
         grid-template-rows: 1fr auto;
     }
 }

--- a/server/src/client/src/styles/var.scss
+++ b/server/src/client/src/styles/var.scss
@@ -14,6 +14,26 @@ $COLOR_TEXT_SECONDARY: var(--b-color-text-secondary);
 $COLOR_TEXT_TERTIARY: var(--b-color-text-tertiary);
 $COLOR_TEXT_MUTED: var(--b-color-text-muted);
 
+$TEXT_SIZE_XS: 0.6875rem;
+$TEXT_SIZE_SM: 0.8125rem;
+$TEXT_SIZE_MD: 0.9375rem;
+$TEXT_SIZE_BASE: 1rem;
+$TEXT_SIZE_LG: 1.0625rem;
+$TEXT_SIZE_TITLE: 1.25rem;
+$TEXT_SIZE_XL: 1.375rem;
+$TEXT_SIZE_2XL: clamp(1.75rem, 2vw, 2.125rem);
+
+$LINE_HEIGHT_DEFAULT: 1.45;
+$LINE_HEIGHT_TIGHT: 1.35;
+$LINE_HEIGHT_HEADING: 1.25;
+$LINE_HEIGHT_DISPLAY: 1.12;
+$LINE_HEIGHT_RELAXED: 1.6;
+
+$FONT_WEIGHT_NORMAL: 400;
+$FONT_WEIGHT_MEDIUM: 500;
+$FONT_WEIGHT_SEMIBOLD: 600;
+$FONT_WEIGHT_BOLD: 700;
+
 /* ACCENT */
 $COLOR_POINT: var(--b-color-point);
 $COLOR_POINT_LIGHT: var(--b-color-point-light);
@@ -64,6 +84,11 @@ $RADIUS_LG: var(--b-radius-lg);
 $RADIUS_XL: var(--b-radius-xl);
 $RADIUS_2XL: var(--b-radius-2xl);
 $RADIUS_FULL: var(--b-radius-full);
+
+/* CONTROL SIZES */
+$CONTROL_HEIGHT_SM: 40px;
+$CONTROL_HEIGHT_MD: 44px;
+$CONTROL_HEIGHT_LG: 48px;
 
 /* LEGACY - deprecated, use new variables */
 $OPACITY_SUB_TEXT: 0.72;


### PR DESCRIPTION
## :dart: Goal

Reduce visual noise across the Ocean Wave client so the interface reads with quieter hierarchy, calmer utility surfaces, and more consistent shared primitive behavior.

## :hammer_and_wrench: Core Changes

- Reduced chrome and decorative weight across the client shell, settings, list items, cards, prompts, confirm dialogs, and standalone auth-related surfaces.
- Normalized shared UI primitives by tightening the typography/control token layer and aligning `Text`, `Button`, `Toggle`, `Select`, `SearchField`, `SettingSection`, `SummaryTitle`, and related shared surfaces to the same hierarchy rules.
- Added a lightweight splash screen surface and simplified settings structure so the client feels more like a focused listening product and less like a control panel.

## :brain: Key Decisions

- Treated this pass as a quieting/refinement step on top of the existing Ocean Wave design, not a fresh rebrand pass.
- Moved typography and control sizing closer to shared tokens so page-level styles stop reintroducing their own mini design systems.
- Reused the shared `Button` primitive inside confirm and prompt layers so action hierarchy is defined once instead of duplicated per modal surface.

## :test_tube: Verification Guide

- `npm run lint --prefix server/src/client`
  Expected: ESLint finishes with no errors or warnings.
- `npm run build --prefix server/src/client`
  Expected: Vite production build completes successfully.
- `CI / build (21.x)` on this PR
  Expected: GitHub Actions check passes before merge.

## :white_check_mark: Checklist

- [x] PR title follows `<emoji> <subject>`.
- [x] Local validation for the changed scope is complete.
- [x] Docs or env changes are not required for this PR.
- [x] This PR is not treated as a release-impacting change.
