### PR TITLE
🐛 Fix playback event tracking

### DIFF
--- a/server/src/client/src/App.tsx
+++ b/server/src/client/src/App.tsx
@@ -117,12 +117,15 @@ export default function App() {
     }, [isAuthLoading, canAccessApp, musicLoaded, showSplash]);
 
     useEffect(() => {
+        const handleConnect = () => {
+            void MusicListener.count();
+        };
+
         const handleWindowFocus = () => {
             if (!canAccessApp) return;
 
             if (!socket.connected) {
                 socket.connect();
-                MusicListener.count();
             }
         };
 
@@ -142,11 +145,13 @@ export default function App() {
         }
 
         socket.connect();
+        socket.on('connect', handleConnect);
         socket.on('connect_error', handleConnectError);
         window.addEventListener('focus', handleWindowFocus);
         window.addEventListener('beforeunload', handleBeforeUnload);
 
         return () => {
+            socket.off('connect', handleConnect);
             socket.off('connect_error', handleConnectError);
             window.removeEventListener('focus', handleWindowFocus);
             window.removeEventListener('beforeunload', handleBeforeUnload);

--- a/server/src/client/src/api/index.ts
+++ b/server/src/client/src/api/index.ts
@@ -74,6 +74,8 @@ export function getMusics() {
             'codec',
             'duration',
             'playCount',
+            'lastPlayedAt',
+            'totalPlayedMs',
             'trackNumber',
             'isLiked',
             'isHated',

--- a/server/src/client/src/models/type.ts
+++ b/server/src/client/src/models/type.ts
@@ -7,6 +7,8 @@ export interface Music {
     sampleRate: number;
     trackNumber: number;
     playCount: number;
+    lastPlayedAt: string | null;
+    totalPlayedMs: number;
     filePath: string;
     isLiked: boolean;
     isHated: boolean;

--- a/server/src/client/src/modules/playback-session.test.ts
+++ b/server/src/client/src/modules/playback-session.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { PlaybackSessionTracker } from './playback-session';
+
+describe('PlaybackSessionTracker', () => {
+    it('tracks only real listening time across ticks and pauses', () => {
+        const tracker = new PlaybackSessionTracker();
+
+        tracker.play({
+            id: 'track-1',
+            durationMs: 200_000
+        }, 1_000);
+        tracker.tick(1_400);
+        tracker.tick(1_900);
+        tracker.pause(2_100);
+        tracker.play({
+            id: 'track-1',
+            durationMs: 200_000
+        }, 5_000);
+        tracker.tick(5_300);
+
+        expect(tracker.commit(5_500)).toEqual({
+            id: 'track-1',
+            playedMs: 1_600,
+            completionRate: expect.closeTo(0.008, 10),
+            startedAt: new Date(1_000).toISOString()
+        });
+    });
+
+    it('does not count paused gaps or seek jumps as listened time', () => {
+        const tracker = new PlaybackSessionTracker();
+
+        tracker.play({
+            id: 'track-2',
+            durationMs: 180_000
+        }, 10_000);
+        tracker.tick(10_300);
+        tracker.pause(10_300);
+
+        tracker.play({
+            id: 'track-2',
+            durationMs: 180_000
+        }, 20_000);
+        tracker.tick(20_200);
+
+        expect(tracker.commit(20_400)).toEqual({
+            id: 'track-2',
+            playedMs: 700,
+            completionRate: expect.closeTo(700 / 180_000, 10),
+            startedAt: new Date(10_000).toISOString()
+        });
+    });
+
+    it('resets after commit so the next track starts a fresh session', () => {
+        const tracker = new PlaybackSessionTracker();
+
+        tracker.play({
+            id: 'track-1',
+            durationMs: 120_000
+        }, 1_000);
+        tracker.tick(2_000);
+
+        expect(tracker.commit(2_500)).toEqual({
+            id: 'track-1',
+            playedMs: 1_500,
+            completionRate: expect.closeTo(0.0125, 10),
+            startedAt: new Date(1_000).toISOString()
+        });
+
+        tracker.play({
+            id: 'track-2',
+            durationMs: 60_000
+        }, 5_000);
+        tracker.tick(5_600);
+
+        expect(tracker.commit(5_800)).toEqual({
+            id: 'track-2',
+            playedMs: 800,
+            completionRate: expect.closeTo(800 / 60_000, 10),
+            startedAt: new Date(5_000).toISOString()
+        });
+    });
+});

--- a/server/src/client/src/modules/playback-session.ts
+++ b/server/src/client/src/modules/playback-session.ts
@@ -1,0 +1,106 @@
+export interface PlaybackSessionTrack {
+    id: string;
+    durationMs: number;
+}
+
+export interface PlaybackSessionCommit {
+    id: string;
+    playedMs: number;
+    completionRate: number;
+    startedAt: string;
+}
+
+const normalizeDurationMs = (durationMs: number) => {
+    return Math.max(Math.round(durationMs), 1);
+};
+
+export class PlaybackSessionTracker {
+    private trackId: string | null = null;
+    private durationMs = 0;
+    private listenedMs = 0;
+    private startedAtMs: number | null = null;
+    private lastTickAtMs: number | null = null;
+    private active = false;
+
+    play(track: PlaybackSessionTrack, now = Date.now()) {
+        this.ensureTrack(track, now);
+
+        if (!this.active) {
+            this.active = true;
+            this.lastTickAtMs = now;
+        }
+    }
+
+    tick(now = Date.now()) {
+        if (!this.active || this.lastTickAtMs === null) {
+            return;
+        }
+
+        this.listenedMs += Math.max(now - this.lastTickAtMs, 0);
+        this.lastTickAtMs = now;
+    }
+
+    pause(now = Date.now()) {
+        if (!this.active) {
+            return;
+        }
+
+        this.tick(now);
+        this.active = false;
+        this.lastTickAtMs = null;
+    }
+
+    commit(now = Date.now()): PlaybackSessionCommit | null {
+        this.pause(now);
+
+        if (!this.trackId || this.startedAtMs === null) {
+            this.reset();
+            return null;
+        }
+
+        const playedMs = Math.max(Math.round(this.listenedMs), 0);
+
+        if (playedMs <= 0) {
+            this.reset();
+            return null;
+        }
+
+        const payload: PlaybackSessionCommit = {
+            id: this.trackId,
+            playedMs,
+            completionRate: Math.min(playedMs / normalizeDurationMs(this.durationMs), 1),
+            startedAt: new Date(this.startedAtMs).toISOString()
+        };
+
+        this.reset();
+
+        return payload;
+    }
+
+    reset() {
+        this.trackId = null;
+        this.durationMs = 0;
+        this.listenedMs = 0;
+        this.startedAtMs = null;
+        this.lastTickAtMs = null;
+        this.active = false;
+    }
+
+    private ensureTrack(track: PlaybackSessionTrack, now: number) {
+        if (this.trackId !== track.id) {
+            this.trackId = track.id;
+            this.durationMs = normalizeDurationMs(track.durationMs);
+            this.listenedMs = 0;
+            this.startedAtMs = now;
+            this.lastTickAtMs = null;
+            this.active = false;
+            return;
+        }
+
+        this.durationMs = normalizeDurationMs(track.durationMs);
+
+        if (this.startedAtMs === null) {
+            this.startedAtMs = now;
+        }
+    }
+}

--- a/server/src/client/src/modules/queue-selection.test.ts
+++ b/server/src/client/src/modules/queue-selection.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { getNextSelectedIndexAfterRemovingCurrent } from './queue-selection';
+
+describe('getNextSelectedIndexAfterRemovingCurrent', () => {
+    it('keeps the same index when a following item still exists', () => {
+        expect(getNextSelectedIndexAfterRemovingCurrent(1, 3)).toBe(1);
+    });
+
+    it('falls back to the last valid index when the removed item was the final item', () => {
+        expect(getNextSelectedIndexAfterRemovingCurrent(2, 2)).toBe(1);
+    });
+
+    it('returns zero when the first item is removed and one item remains', () => {
+        expect(getNextSelectedIndexAfterRemovingCurrent(0, 1)).toBe(0);
+    });
+});

--- a/server/src/client/src/modules/queue-selection.ts
+++ b/server/src/client/src/modules/queue-selection.ts
@@ -1,0 +1,6 @@
+export const getNextSelectedIndexAfterRemovingCurrent = (
+    prevSelected: number,
+    nextLength: number
+) => {
+    return Math.min(prevSelected, nextLength - 1);
+};

--- a/server/src/client/src/socket/music-listener.ts
+++ b/server/src/client/src/socket/music-listener.ts
@@ -5,6 +5,14 @@ export const MUSIC_LIKE = 'music-like';
 export const MUSIC_HATE = 'music-hate';
 export const MUSIC_COUNT = 'music-count';
 
+export interface CountPayload {
+    id: string;
+    playedMs: number;
+    completionRate: number;
+    startedAt: string;
+    source?: string;
+}
+
 interface Like {
     id: string;
     isLiked: boolean;
@@ -18,6 +26,9 @@ interface Hate {
 interface Count {
     id: string;
     playCount: number;
+    lastPlayedAt: string | null;
+    totalPlayedMs: number;
+    countedAsPlay: boolean;
 }
 
 interface MusicListenerEventHandler {
@@ -27,7 +38,8 @@ interface MusicListenerEventHandler {
 }
 
 export class MusicListener implements Listener {
-    static shouldIncreaseItems: string[] = [];
+    static pendingCountEvents: CountPayload[] = [];
+    static isFlushing = false;
 
     handler: MusicListenerEventHandler | null;
 
@@ -57,22 +69,29 @@ export class MusicListener implements Listener {
         socket.emit(MUSIC_HATE, { id });
     }
 
-    static async count(id?: string) {
-        id && this.shouldIncreaseItems.push(id);
+    static async count(payload?: CountPayload) {
+        if (payload) {
+            this.pendingCountEvents.push(payload);
+        }
 
-        if (!socket.connected) {
+        if (!socket.connected || this.isFlushing) {
             return;
         }
 
-        while (this.shouldIncreaseItems.length > 0) {
-            const itemId = this.shouldIncreaseItems.pop();
+        this.isFlushing = true;
 
-            if (!itemId) {
-                break;
+        try {
+            while (this.pendingCountEvents.length > 0) {
+                const item = this.pendingCountEvents.shift();
+
+                if (!item) {
+                    break;
+                }
+
+                socket.emit(MUSIC_COUNT, item);
             }
-
-            await new Promise(resolve => setTimeout(resolve, 1000));
-            socket.emit(MUSIC_COUNT, { id: itemId });
+        } finally {
+            this.isFlushing = false;
         }
     }
 

--- a/server/src/client/src/store/music.ts
+++ b/server/src/client/src/store/music.ts
@@ -61,11 +61,13 @@ class MusicStore extends Store<MusicStoreState> {
                     })
                 });
             },
-            onCount: ({ id, playCount }) => {
+            onCount: ({ id, playCount, lastPlayedAt, totalPlayedMs }) => {
                 this.set((prevState) => {
                     let nextMusics = prevState.musics.map((music) => {
                         if (music.id === id) {
                             music.playCount = playCount;
+                            music.lastPlayedAt = lastPlayedAt;
+                            music.totalPlayedMs = totalPlayedMs;
                         }
                         return music;
                     });

--- a/server/src/client/src/store/queue.ts
+++ b/server/src/client/src/store/queue.ts
@@ -10,6 +10,8 @@ import {
 } from '~/modules/audio-channel';
 import { confirm } from '~/modules/confirm';
 import { toast } from '~/modules/toast';
+import { convertToMillisecond } from '~/modules/time';
+import { PlaybackSessionTracker } from '~/modules/playback-session';
 import { MusicListener } from '~/socket';
 import { shuffle } from '~/modules/shuffle';
 
@@ -34,12 +36,13 @@ const getMusic = (id: string) => {
 
 class QueueStore extends Store<QueueStoreState> {
     saveTimer: ReturnType<typeof setTimeout> | null = null;
-    shouldCount = false;
     audioChannel: AudioChannel;
+    playbackSessionTracker: PlaybackSessionTracker;
 
     constructor() {
         super();
         this.saveTimer = null;
+        this.playbackSessionTracker = new PlaybackSessionTracker();
         this.state = {
             selected: null,
             isPlaying: false,
@@ -56,31 +59,50 @@ class QueueStore extends Store<QueueStoreState> {
 
         const audioChannelEventHandler: AudioChannelEventHandler = {
             onPlay: () => {
+                if (this.state.selected === null) {
+                    return;
+                }
+
+                const currentMusic = getMusic(this.state.items[this.state.selected]);
+
+                if (currentMusic) {
+                    this.playbackSessionTracker.play({
+                        id: currentMusic.id,
+                        durationMs: convertToMillisecond(currentMusic.duration)
+                    });
+                }
+
                 this.set({ isPlaying: true });
             },
             onPause: () => {
+                this.playbackSessionTracker.pause();
                 this.set({ isPlaying: false });
             },
             onStop: () => {
+                this.playbackSessionTracker.pause();
                 this.set({ isPlaying: false });
             },
             onEnded: () => {
                 if (this.state.selected === null) return;
 
                 if (this.state.repeatMode === 'one') {
+                    this.commitPlaybackEvent('queue-repeat-one');
                     this.select(this.state.selected);
                     return;
                 }
                 if (this.state.repeatMode === 'all') {
+                    this.commitPlaybackEvent('queue-track-change');
                     this.select((this.state.selected + 1) % this.state.items.length);
                     this.audioChannel.play();
                     return;
                 }
                 if (this.state.repeatMode === 'none') {
                     if (this.state.selected + 1 < this.state.items.length) {
+                        this.commitPlaybackEvent('queue-track-change');
                         this.select(this.state.selected + 1);
                         this.audioChannel.play();
                     } else {
+                        this.commitPlaybackEvent('queue-ended');
                         this.audioChannel.stop();
                         this.set({ isPlaying: false });
                     }
@@ -90,24 +112,11 @@ class QueueStore extends Store<QueueStoreState> {
                 const music = getMusic(this.state.items[this.state.selected!]);
                 const progress = Number((time / (music?.duration || 1) * 100).toFixed(2));
 
-                if (!this.shouldCount && Math.floor(progress) >= 0 && Math.floor(progress) < 10) {
-                    this.shouldCount = true;
-                }
-
-                if (this.shouldCount && Math.floor(progress) >= 80 && Math.floor(progress) < 90) {
-                    this.shouldCount = false;
-                    MusicListener.count(this.state.items[this.state.selected!]);
-                }
-
                 if (this.state.mixMode === 'mix') {
-                    mix(20, () => {
-                        if (this.shouldCount) {
-                            this.shouldCount = false;
-                            MusicListener.count(this.state.items[this.state.selected!]);
-                        }
-                    });
+                    mix(20, () => undefined);
                 }
 
+                this.playbackSessionTracker.tick();
                 this.set({
                     currentTime: time,
                     progress
@@ -138,7 +147,21 @@ class QueueStore extends Store<QueueStoreState> {
         });
 
         window.addEventListener('beforeunload', () => {
+            this.commitPlaybackEvent('queue-unload');
             this.audioChannel.stop();
+        });
+    }
+
+    commitPlaybackEvent(source: string) {
+        const payload = this.playbackSessionTracker.commit();
+
+        if (!payload) {
+            return;
+        }
+
+        void MusicListener.count({
+            ...payload,
+            source
         });
     }
 
@@ -151,6 +174,9 @@ class QueueStore extends Store<QueueStoreState> {
         }))) {
             return;
         }
+
+        this.commitPlaybackEvent('queue-reset');
+
         await this.set({
             items: ids,
             sourceItems: [],
@@ -213,6 +239,10 @@ class QueueStore extends Store<QueueStoreState> {
             ? this.state.items[prevSelected || 0]
             : null;
 
+        if (prevSelectedItem && ids.includes(prevSelectedItem)) {
+            this.commitPlaybackEvent('queue-remove');
+        }
+
         await this.set({
             items: newItems,
             sourceItems: newSourceItems
@@ -248,6 +278,8 @@ class QueueStore extends Store<QueueStoreState> {
     }
 
     select(index: number, play = true) {
+        this.commitPlaybackEvent('queue-track-change');
+
         this.set({
             selected: index,
             progress: 0,
@@ -275,6 +307,7 @@ class QueueStore extends Store<QueueStoreState> {
     }
 
     stop() {
+        this.commitPlaybackEvent('queue-stop');
         this.audioChannel.stop();
     }
 

--- a/server/src/client/src/store/queue.ts
+++ b/server/src/client/src/store/queue.ts
@@ -9,6 +9,7 @@ import {
     AppAudioChannel
 } from '~/modules/audio-channel';
 import { confirm } from '~/modules/confirm';
+import { getNextSelectedIndexAfterRemovingCurrent } from '~/modules/queue-selection';
 import { toast } from '~/modules/toast';
 import { convertToMillisecond } from '~/modules/time';
 import { PlaybackSessionTracker } from '~/modules/playback-session';
@@ -265,14 +266,11 @@ class QueueStore extends Store<QueueStoreState> {
                 return;
             }
             if (ids.includes(prevSelectedItem)) {
-                if (this.state.items.length >= prevSelected!) {
-                    this.select(prevSelected!);
-                    return;
-                }
-                if (this.state.items.length < prevSelected!) {
-                    this.select(this.state.items.length - 1);
-                    return;
-                }
+                this.select(getNextSelectedIndexAfterRemovingCurrent(
+                    prevSelected!,
+                    this.state.items.length
+                ));
+                return;
             }
         }
     }

--- a/server/src/prisma/migrations/20260409090000_0003_playback_history_foundation/migration.sql
+++ b/server/src/prisma/migrations/20260409090000_0003_playback_history_foundation/migration.sql
@@ -1,0 +1,21 @@
+-- AlterTable
+ALTER TABLE "Music" ADD COLUMN "lastPlayedAt" DATETIME;
+ALTER TABLE "Music" ADD COLUMN "totalPlayedMs" REAL NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "PlaybackEvent" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "startedAt" DATETIME NOT NULL,
+    "endedAt" DATETIME NOT NULL,
+    "playedMs" REAL NOT NULL,
+    "completionRate" REAL NOT NULL,
+    "countedAsPlay" BOOLEAN NOT NULL DEFAULT false,
+    "source" TEXT NOT NULL,
+    "connectorId" TEXT,
+    "musicId" INTEGER NOT NULL,
+    CONSTRAINT "PlaybackEvent_musicId_fkey" FOREIGN KEY ("musicId") REFERENCES "Music" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateIndex
+CREATE INDEX "PlaybackEvent_musicId_endedAt_idx" ON "PlaybackEvent"("musicId", "endedAt");

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -55,11 +55,30 @@ model Music {
     bitrate       Float
     sampleRate    Float
     playCount     Int             @default(0)
+    lastPlayedAt  DateTime?
+    totalPlayedMs Float           @default(0)
     trackNumber   Int
     Genre         Genre[]
     MusicLike     MusicLike[]
     MusicHate     MusicHate[]
+    PlaybackEvent PlaybackEvent[]
     PlaylistMusic PlaylistMusic[]
+}
+
+model PlaybackEvent {
+    id             Int      @id @default(autoincrement())
+    createdAt      DateTime @default(now())
+    startedAt      DateTime
+    endedAt        DateTime
+    playedMs       Float
+    completionRate Float
+    countedAsPlay  Boolean  @default(false)
+    source         String
+    connectorId    String?
+    Music          Music    @relation(fields: [musicId], references: [id])
+    musicId        Int
+
+    @@index([musicId, endedAt])
 }
 
 model MusicLike {

--- a/server/src/src/schema/music/index.ts
+++ b/server/src/src/schema/music/index.ts
@@ -14,6 +14,8 @@ export const musicType = gql`
         bitrate: Float!
         sampleRate: Float!
         playCount: Int!
+        lastPlayedAt: String
+        totalPlayedMs: Float!
         trackNumber: Int!
         filePath: String!
         isLiked: Boolean!

--- a/server/src/src/socket/music.test.ts
+++ b/server/src/src/socket/music.test.ts
@@ -1,0 +1,129 @@
+import models from '~/models';
+import { connectors } from './connectors';
+import { count } from './music';
+
+const createMusic = async (overrides?: { duration?: number }) => {
+    const unique = Date.now().toString() + Math.random().toString(16).slice(2);
+    const artist = await models.artist.create({ data: { name: `Artist ${unique}` } });
+    const album = await models.album.create({
+        data: {
+            name: `Album ${unique}`,
+            cover: `/covers/${unique}.jpg`,
+            publishedYear: '2026',
+            artistId: artist.id
+        }
+    });
+
+    return models.music.create({
+        data: {
+            name: `Track ${unique}`,
+            artistId: artist.id,
+            albumId: album.id,
+            filePath: `/music/${unique}.mp3`,
+            duration: overrides?.duration ?? 200,
+            codec: 'mp3',
+            container: 'mp3',
+            bitrate: 320,
+            sampleRate: 44100,
+            trackNumber: 1
+        }
+    });
+};
+
+describe('music playback counting', () => {
+    beforeEach(async () => {
+        jest.restoreAllMocks();
+
+        await models.playbackEvent.deleteMany();
+        await models.musicLike.deleteMany();
+        await models.musicHate.deleteMany();
+        await models.playlistMusic.deleteMany();
+        await models.music.deleteMany();
+        await models.album.deleteMany();
+        await models.artist.deleteMany();
+    });
+
+    it('creates a playback event and updates aggregates for a meaningful listen', async () => {
+        const broadcastSpy = jest.spyOn(connectors, 'broadcast').mockResolvedValue([]);
+        const music = await createMusic({ duration: 180 });
+
+        await count({
+            id: music.id.toString(),
+            playedMs: 35_000,
+            completionRate: 35_000 / 180_000,
+            source: 'queue-track-change'
+        });
+
+        const updatedMusic = await models.music.findUniqueOrThrow({ where: { id: music.id } });
+        const events = await models.playbackEvent.findMany({ where: { musicId: music.id } });
+
+        expect(updatedMusic.playCount).toBe(1);
+        expect(updatedMusic.totalPlayedMs).toBe(35_000);
+        expect(updatedMusic.lastPlayedAt).not.toBeNull();
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            musicId: music.id,
+            playedMs: 35_000,
+            countedAsPlay: true,
+            source: 'queue-track-change'
+        });
+        expect(broadcastSpy).toHaveBeenCalledWith('music-count', expect.objectContaining({
+            id: music.id.toString(),
+            playCount: 1,
+            totalPlayedMs: 35_000,
+            countedAsPlay: true
+        }));
+    });
+
+    it('records partial playback without incrementing play count', async () => {
+        const broadcastSpy = jest.spyOn(connectors, 'broadcast').mockResolvedValue([]);
+        const music = await createMusic({ duration: 240 });
+
+        await count({
+            id: music.id.toString(),
+            playedMs: 10_000,
+            completionRate: 10_000 / 240_000,
+            source: 'queue-stop'
+        });
+
+        const updatedMusic = await models.music.findUniqueOrThrow({ where: { id: music.id } });
+        const event = await models.playbackEvent.findFirstOrThrow({ where: { musicId: music.id } });
+
+        expect(updatedMusic.playCount).toBe(0);
+        expect(updatedMusic.totalPlayedMs).toBe(10_000);
+        expect(event.countedAsPlay).toBe(false);
+        expect(broadcastSpy).toHaveBeenCalledWith('music-count', expect.objectContaining({
+            id: music.id.toString(),
+            playCount: 0,
+            totalPlayedMs: 10_000,
+            countedAsPlay: false
+        }));
+    });
+
+    it('clamps playedMs to the session wall-clock duration when startedAt is provided', async () => {
+        const broadcastSpy = jest.spyOn(connectors, 'broadcast').mockResolvedValue([]);
+        const music = await createMusic({ duration: 180 });
+        const startedAt = new Date(Date.now() - 5_000).toISOString();
+
+        await count({
+            id: music.id.toString(),
+            playedMs: 60_000,
+            completionRate: 60_000 / 180_000,
+            startedAt,
+            source: 'queue-stop'
+        });
+
+        const updatedMusic = await models.music.findUniqueOrThrow({ where: { id: music.id } });
+        const event = await models.playbackEvent.findFirstOrThrow({ where: { musicId: music.id } });
+
+        expect(updatedMusic.playCount).toBe(0);
+        expect(updatedMusic.totalPlayedMs).toBeLessThanOrEqual(5_100);
+        expect(event.playedMs).toBeLessThanOrEqual(5_100);
+        expect(Math.abs(event.startedAt.getTime() - new Date(startedAt).getTime())).toBeLessThan(50);
+        expect(broadcastSpy).toHaveBeenCalledWith('music-count', expect.objectContaining({
+            id: music.id.toString(),
+            playCount: 0,
+            countedAsPlay: false
+        }));
+    });
+});

--- a/server/src/src/socket/music.ts
+++ b/server/src/src/socket/music.ts
@@ -8,6 +8,38 @@ export const MUSIC_LIKE = 'music-like';
 export const MUSIC_HATE = 'music-hate';
 export const MUSIC_COUNT = 'music-count';
 
+const PLAY_COUNT_MIN_MS = 30_000;
+const SHORT_TRACK_COUNT_THRESHOLD = 0.5;
+
+interface CountPayload {
+    id?: string;
+    playedMs?: number;
+    completionRate?: number;
+    startedAt?: string;
+    source?: string;
+    connectorId?: string | null;
+}
+
+const clamp = (value: number, min: number, max: number) => {
+    return Math.min(Math.max(value, min), max);
+};
+
+const shouldCountAsPlay = ({
+    durationSeconds,
+    playedMs
+}: {
+    durationSeconds: number;
+    playedMs: number;
+}) => {
+    const durationMs = Math.max(durationSeconds * 1000, 0);
+    const minimumMeaningfulPlayMs = Math.min(
+        PLAY_COUNT_MIN_MS,
+        durationMs * SHORT_TRACK_COUNT_THRESHOLD
+    );
+
+    return playedMs >= minimumMeaningfulPlayMs;
+};
+
 export const musicListener = (socket: Socket) => {
     socket.on(MUSIC_LIKE, like);
     socket.on(MUSIC_HATE, hate);
@@ -68,7 +100,14 @@ export const hate = async ({ id = '' }) => {
     }
 };
 
-export const count = async ({ id = '' }) => {
+export const count = async ({
+    id = '',
+    playedMs = 0,
+    completionRate,
+    startedAt,
+    source = 'queue',
+    connectorId = null
+}: CountPayload) => {
     if (!id) {
         return;
     }
@@ -76,14 +115,73 @@ export const count = async ({ id = '' }) => {
     const $music = await models.music.findUnique({ where: { id: parseInt(id) } });
 
     if ($music) {
-        console.log('count update', $music.name, $music.playCount + 1);
-        await models.music.update({
-            where: { id: parseInt(id) },
-            data: { playCount: $music.playCount + 1 }
+        const endedAt = new Date();
+        const requestedStartedAt = startedAt ? new Date(startedAt) : null;
+        const validStartedAtMs = requestedStartedAt && !Number.isNaN(requestedStartedAt.getTime())
+            ? requestedStartedAt.getTime()
+            : null;
+        const resolvedStartedAt = validStartedAtMs !== null
+            ? new Date(Math.min(validStartedAtMs, endedAt.getTime()))
+            : new Date(endedAt.getTime() - Math.max(playedMs, 0));
+        const elapsedWallClockMs = Math.max(
+            endedAt.getTime() - resolvedStartedAt.getTime(),
+            0
+        );
+        const maxPlayedMs = validStartedAtMs !== null
+            ? elapsedWallClockMs
+            : Math.max($music.duration * 1000, PLAY_COUNT_MIN_MS);
+        const normalizedPlayedMs = clamp(playedMs, 0, maxPlayedMs);
+
+        if (normalizedPlayedMs <= 0) {
+            return;
+        }
+
+        const normalizedCompletionRate = clamp(
+            completionRate ?? normalizedPlayedMs / Math.max($music.duration * 1000, 1),
+            0,
+            1
+        );
+        const countedAsPlay = shouldCountAsPlay({
+            durationSeconds: $music.duration,
+            playedMs: normalizedPlayedMs
         });
-        connectors.broadcast(MUSIC_COUNT, {
-            id: $music.id.toString(),
-            playCount: $music.playCount + 1
+        const updatedMusic = await models.$transaction(async (tx) => {
+            await tx.playbackEvent.create({
+                data: {
+                    musicId: $music.id,
+                    startedAt: resolvedStartedAt,
+                    endedAt,
+                    playedMs: normalizedPlayedMs,
+                    completionRate: normalizedCompletionRate,
+                    countedAsPlay,
+                    source,
+                    connectorId: connectorId ?? undefined
+                }
+            });
+
+            return tx.music.update({
+                where: { id: $music.id },
+                data: {
+                    playCount: countedAsPlay
+                        ? { increment: 1 }
+                        : undefined,
+                    lastPlayedAt: endedAt,
+                    totalPlayedMs: { increment: normalizedPlayedMs }
+                },
+                select: {
+                    id: true,
+                    playCount: true,
+                    totalPlayedMs: true
+                }
+            });
+        });
+
+        await connectors.broadcast(MUSIC_COUNT, {
+            id: updatedMusic.id.toString(),
+            playCount: updatedMusic.playCount,
+            lastPlayedAt: endedAt.toISOString(),
+            totalPlayedMs: updatedMusic.totalPlayedMs,
+            countedAsPlay
         });
     }
 };


### PR DESCRIPTION
## :dart: Goal
Stabilize playback event tracking so listen sessions remain useful for history and analytics, and fix the queue removal edge case that could select an out-of-range item after removing the currently playing last track.

## :hammer_and_wrench: Core Changes
- Added playback-event foundation on the server with `PlaybackEvent`, `lastPlayedAt`, and `totalPlayedMs` so raw listen sessions and derived aggregates can coexist.
- Reworked client playback tracking to accumulate real listened time across play, pause, resume, stop, and track transitions instead of using raw seek position.
- Added a focused queue selection helper and test to guard the last-item removal edge case when removing the currently selected track.
- Updated socket payloads and server handling to carry `startedAt`, clamp invalid durations, and apply aggregate updates with atomic increments.

## :brain: Key Decisions
- Kept `PlaybackEvent` as the source of truth and treated `playCount`, `lastPlayedAt`, and `totalPlayedMs` as derived aggregates.
- Measured listened time from active playback windows rather than current media position so seek jumps do not inflate analytics.
- Chose a pure helper plus unit test for queue removal selection because the bug was an index contract issue, not a UI rendering issue.

## :test_tube: Verification Guide
- `cd server/src && pnpm test -- --runInBand src/socket/music.test.ts`
  - Passed. Playback event persistence, partial listens, and started-at clamping all succeeded.
- `cd server/src && pnpm build`
  - Passed.
- `cd server/src && pnpm lint`
  - Passed with existing repository `no-console` warnings only.
- `cd server/src/client && pnpm test src/modules/playback-session.test.ts`
  - Passed.
- `cd server/src/client && pnpm test src/modules/queue-selection.test.ts`
  - Passed.
- `cd server/src/client && pnpm build`
  - Passed.
- `cd server/src/client && pnpm lint`
  - Passed.

## :white_check_mark: Checklist
- [x] Playback event tracking stores raw session data and updates derived aggregates.
- [x] Queue removal no longer selects an out-of-range index after removing the active last item.
- [x] Changed scope was validated locally.
- [ ] CI has not run yet.
