### PR TITLE
⚡ Improve queue virtualization and drag reorder

### DIFF
--- a/server/src/client/src/components/music/MusicPlayer/MusicPlayer.tsx
+++ b/server/src/client/src/components/music/MusicPlayer/MusicPlayer.tsx
@@ -8,17 +8,22 @@ import { useNavigate } from 'react-router-dom';
 import { Image } from '~/components/shared';
 import * as Icon from '~/icon';
 
+import { useStoreValue } from '~/hooks';
 import { musicStore } from '~/store/music';
 import { queueStore } from '~/store/queue';
 
 const MusicPlayer = () => {
     const navigate = useNavigate();
 
-    const [state] = useStore(queueStore);
+    const [currentTrackId] = useStoreValue(queueStore, 'currentTrackId');
+    const [progress] = useStoreValue(queueStore, 'progress');
+    const [isPlaying] = useStoreValue(queueStore, 'isPlaying');
+    const [repeatMode] = useStoreValue(queueStore, 'repeatMode');
+    const [shuffle] = useStoreValue(queueStore, 'shuffle');
     const [{ musicMap }] = useStore(musicStore);
 
-    const currentMusic = state.selected !== null
-        ? musicMap.get(state.items[state.selected])
+    const currentMusic = currentTrackId
+        ? musicMap.get(currentTrackId)
         : null;
 
     // TODO: Fix type
@@ -52,7 +57,7 @@ const MusicPlayer = () => {
             <div
                 className={cx('progress')}
                 role="progressbar"
-                aria-valuenow={state.progress}
+                aria-valuenow={progress}
                 aria-valuemin={0}
                 aria-valuemax={100}
                 onClick={handleClickProgress}
@@ -60,7 +65,7 @@ const MusicPlayer = () => {
                 onTouchMove={handleMoveProgress}>
                 <div
                     className={cx('bar')}
-                    style={{ transform: `translateX(-${100 - state.progress}%)` }}
+                    style={{ transform: `translateX(-${100 - progress}%)` }}
                 />
             </div>
             <div className={cx('content')}>
@@ -92,9 +97,9 @@ const MusicPlayer = () => {
                     <button
                         className={cx('controlButton', 'secondary')}
                         onClick={() => queueStore.changeRepeatMode()}>
-                        {state.repeatMode === 'all' && <Icon.Repeat />}
-                        {state.repeatMode === 'one' && <Icon.Infinite />}
-                        {state.repeatMode === 'none' && <Icon.RightLeft />}
+                        {repeatMode === 'all' && <Icon.Repeat />}
+                        {repeatMode === 'one' && <Icon.Infinite />}
+                        {repeatMode === 'none' && <Icon.RightLeft />}
                     </button>
                     <button
                         className={cx('controlButton', 'secondary')}
@@ -103,8 +108,8 @@ const MusicPlayer = () => {
                     </button>
                     <button
                         className={cx('controlButton', 'primary')}
-                        onClick={() => state.isPlaying ? queueStore.pause() : queueStore.play()}>
-                        {state.isPlaying ? <Icon.Pause /> : <Icon.Play />}
+                        onClick={() => isPlaying ? queueStore.pause() : queueStore.play()}>
+                        {isPlaying ? <Icon.Pause /> : <Icon.Play />}
                     </button>
                     <button
                         className={cx('controlButton', 'secondary')}
@@ -112,7 +117,7 @@ const MusicPlayer = () => {
                         <Icon.SkipForward />
                     </button>
                     <button
-                        className={cx('controlButton', 'secondary', { active: state.shuffle })}
+                        className={cx('controlButton', 'secondary', { active: shuffle })}
                         onClick={() => queueStore.toggleShuffle()}>
                         <Icon.Shuffle />
                     </button>

--- a/server/src/client/src/hooks/index.ts
+++ b/server/src/client/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { default as useBack } from './useBack';
 export { default as useDragDismiss } from './useDragDismiss';
+export { default as useStoreValue } from './useStoreValue';

--- a/server/src/client/src/hooks/useStoreValue.ts
+++ b/server/src/client/src/hooks/useStoreValue.ts
@@ -1,0 +1,6 @@
+import type Store from 'badland';
+import { useValue } from 'badland-react';
+
+export default function useStoreValue<T, K extends keyof T>(store: Store<T>, name: K) {
+    return useValue(store, name) as unknown as [T[K], (value: T[K]) => Promise<T>];
+}

--- a/server/src/client/src/modules/queue-state.test.ts
+++ b/server/src/client/src/modules/queue-state.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    deriveQueueState,
+    deriveQueueStateFromTrack,
+    moveQueueItemToIndex,
+    reorderQueueItems
+} from './queue-state';
+
+describe('queue-state', () => {
+    it('derives the current track id and queue length from a valid selection', () => {
+        expect(deriveQueueState(['a', 'b', 'c'], 1)).toEqual({
+            selected: 1,
+            currentTrackId: 'b',
+            queueLength: 3
+        });
+    });
+
+    it('preserves the selected track when the queue shape changes', () => {
+        expect(deriveQueueStateFromTrack(['x', 'a', 'b'], 'a')).toEqual({
+            selected: 1,
+            currentTrackId: 'a',
+            queueLength: 3
+        });
+    });
+
+    it('clears selection when the selected track disappears from the queue', () => {
+        expect(deriveQueueStateFromTrack(['a', 'c'], 'b')).toEqual({
+            selected: null,
+            currentTrackId: null,
+            queueLength: 2
+        });
+    });
+
+    it('reorders queue items by id', () => {
+        expect(reorderQueueItems(['a', 'b', 'c', 'd'], 'd', 'b')).toEqual([
+            'a',
+            'd',
+            'b',
+            'c'
+        ]);
+    });
+
+    it('moves a queue item to an explicit index', () => {
+        expect(moveQueueItemToIndex(['a', 'b', 'c', 'd'], 'a', 2)).toEqual([
+            'b',
+            'c',
+            'a',
+            'd'
+        ]);
+    });
+});

--- a/server/src/client/src/modules/queue-state.ts
+++ b/server/src/client/src/modules/queue-state.ts
@@ -1,0 +1,77 @@
+export interface QueueDerivedState {
+    selected: number | null;
+    currentTrackId: string | null;
+    queueLength: number;
+}
+
+const isValidSelectedIndex = (items: string[], selected: number | null) => {
+    return selected !== null && selected >= 0 && selected < items.length;
+};
+
+export const getCurrentTrackId = (items: string[], selected: number | null) => {
+    if (selected === null) {
+        return null;
+    }
+
+    if (!isValidSelectedIndex(items, selected)) {
+        return null;
+    }
+
+    return items[selected];
+};
+
+export const getSelectedIndexForTrack = (items: string[], trackId: string | null) => {
+    if (!trackId) {
+        return null;
+    }
+
+    const index = items.indexOf(trackId);
+
+    return index >= 0 ? index : null;
+};
+
+export const deriveQueueState = (items: string[], selected: number | null): QueueDerivedState => {
+    const currentTrackId = getCurrentTrackId(items, selected);
+
+    return {
+        selected: currentTrackId === null ? null : selected,
+        currentTrackId,
+        queueLength: items.length
+    };
+};
+
+export const deriveQueueStateFromTrack = (items: string[], trackId: string | null) => {
+    return deriveQueueState(items, getSelectedIndexForTrack(items, trackId));
+};
+
+export const reorderQueueItems = (items: string[], activeId: string, overId: string) => {
+    const oldIndex = items.indexOf(activeId);
+    const newIndex = items.indexOf(overId);
+
+    if (oldIndex < 0 || newIndex < 0 || oldIndex === newIndex) {
+        return items;
+    }
+
+    return moveQueueItemToIndex(items, activeId, newIndex);
+};
+
+export const moveQueueItemToIndex = (items: string[], activeId: string, targetIndex: number) => {
+    const oldIndex = items.indexOf(activeId);
+
+    if (oldIndex < 0) {
+        return items;
+    }
+
+    const safeTargetIndex = Math.min(Math.max(targetIndex, 0), items.length - 1);
+
+    if (oldIndex === safeTargetIndex) {
+        return items;
+    }
+
+    const nextItems = [...items];
+    const [movedItem] = nextItems.splice(oldIndex, 1);
+
+    nextItems.splice(safeTargetIndex, 0, movedItem);
+
+    return nextItems;
+};

--- a/server/src/client/src/modules/queue-virtual-rows.test.ts
+++ b/server/src/client/src/modules/queue-virtual-rows.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    QUEUE_SECTION_ROW_HEIGHT,
+    QUEUE_TRACK_CARD_HEIGHT,
+    QUEUE_TRACK_ROW_GAP,
+    QUEUE_TRACK_ROW_HEIGHT,
+    buildQueueVirtualLayout,
+    findQueueDropSlot,
+    findQueueTrackRow,
+    getQueueDropIndicatorTop,
+    getVisibleQueueVirtualRows,
+    resolveQueueDropIndex
+} from './queue-virtual-rows';
+
+describe('queue-virtual-rows', () => {
+    it('builds sectioned rows around the current track', () => {
+        const layout = buildQueueVirtualLayout(['a', 'b', 'c', 'd'], 1);
+
+        expect(layout.rows.map((row) => row.type === 'section' ? row.label : `${row.tone}:${row.id}`)).toEqual([
+            'Earlier',
+            'past:a',
+            'current:b',
+            'Up next',
+            'upcoming:c',
+            'upcoming:d'
+        ]);
+        expect(layout.totalHeight).toBe(
+            QUEUE_SECTION_ROW_HEIGHT * 2 + QUEUE_TRACK_ROW_HEIGHT * 4
+        );
+    });
+
+    it('builds a single queue section when nothing is selected', () => {
+        const layout = buildQueueVirtualLayout(['a', 'b'], -1);
+
+        expect(layout.rows.map((row) => row.type === 'section' ? row.label : row.id)).toEqual([
+            'Queue',
+            'a',
+            'b'
+        ]);
+    });
+
+    it('returns only rows inside the visible range plus overscan', () => {
+        const layout = buildQueueVirtualLayout(['a', 'b', 'c', 'd', 'e'], -1);
+
+        expect(getVisibleQueueVirtualRows(layout.rows, 0, QUEUE_TRACK_ROW_HEIGHT + 10, 0).map((row) => row.key)).toEqual([
+            'section-queue',
+            'a'
+        ]);
+    });
+
+    it('finds the rendered row metadata for a track index', () => {
+        const layout = buildQueueVirtualLayout(['a', 'b', 'c'], 2);
+
+        expect(findQueueTrackRow(layout.rows, 2)).toMatchObject({
+            type: 'track',
+            id: 'c',
+            tone: 'current'
+        });
+    });
+
+    it('resolves drop slots and target indices for drag reorder', () => {
+        const layout = buildQueueVirtualLayout(['a', 'b', 'c'], -1);
+        const firstTrackCenter = QUEUE_SECTION_ROW_HEIGHT + QUEUE_TRACK_ROW_HEIGHT / 2;
+        const lastTrackBottom = QUEUE_SECTION_ROW_HEIGHT + QUEUE_TRACK_ROW_HEIGHT * 3;
+
+        expect(findQueueDropSlot(layout.rows, firstTrackCenter - 8)).toBe(0);
+        expect(findQueueDropSlot(layout.rows, firstTrackCenter + QUEUE_TRACK_ROW_HEIGHT)).toBe(2);
+        expect(findQueueDropSlot(layout.rows, lastTrackBottom + 20)).toBe(3);
+        expect(getQueueDropIndicatorTop(layout.rows, 2)).toBe(
+            QUEUE_SECTION_ROW_HEIGHT + QUEUE_TRACK_ROW_HEIGHT * 2
+        );
+        expect(getQueueDropIndicatorTop(layout.rows, 0)).toBe(
+            QUEUE_SECTION_ROW_HEIGHT + QUEUE_TRACK_ROW_GAP / 2
+        );
+        expect(getQueueDropIndicatorTop(layout.rows, 3)).toBe(
+            QUEUE_SECTION_ROW_HEIGHT + QUEUE_TRACK_ROW_HEIGHT * 3 - QUEUE_TRACK_ROW_GAP / 2
+        );
+        expect(QUEUE_TRACK_CARD_HEIGHT + QUEUE_TRACK_ROW_GAP).toBe(QUEUE_TRACK_ROW_HEIGHT);
+        expect(resolveQueueDropIndex(3, 0, 2)).toBe(1);
+        expect(resolveQueueDropIndex(3, 2, 0)).toBe(0);
+    });
+});

--- a/server/src/client/src/modules/queue-virtual-rows.ts
+++ b/server/src/client/src/modules/queue-virtual-rows.ts
@@ -1,0 +1,187 @@
+import type { QueueTone } from '~/pages/Queue/QueueDndItem';
+
+export const QUEUE_TRACK_CARD_HEIGHT = 84;
+export const QUEUE_TRACK_ROW_GAP = 8;
+export const QUEUE_TRACK_ROW_HEIGHT = QUEUE_TRACK_CARD_HEIGHT + QUEUE_TRACK_ROW_GAP;
+export const QUEUE_SECTION_ROW_HEIGHT = 30;
+export const QUEUE_VIRTUAL_OVERSCAN_PX = QUEUE_TRACK_ROW_HEIGHT * 5;
+
+interface QueueVirtualRowBase {
+    key: string;
+    top: number;
+    height: number;
+}
+
+export interface QueueVirtualSectionRow extends QueueVirtualRowBase {
+    type: 'section';
+    current?: boolean;
+    label: string;
+}
+
+export interface QueueVirtualTrackRow extends QueueVirtualRowBase {
+    type: 'track';
+    id: string;
+    index: number;
+    tone: QueueTone;
+}
+
+export type QueueVirtualRow = QueueVirtualSectionRow | QueueVirtualTrackRow;
+
+export interface QueueVirtualLayout {
+    rows: QueueVirtualRow[];
+    totalHeight: number;
+}
+
+const appendSectionRow = (
+    rows: QueueVirtualRow[],
+    key: string,
+    label: string,
+    top: number,
+    current = false
+) => {
+    rows.push({
+        type: 'section',
+        key,
+        label,
+        current,
+        top,
+        height: QUEUE_SECTION_ROW_HEIGHT
+    });
+
+    return top + QUEUE_SECTION_ROW_HEIGHT;
+};
+
+const appendTrackRows = (
+    rows: QueueVirtualRow[],
+    items: string[],
+    startIndex: number,
+    endIndex: number,
+    tone: QueueTone,
+    top: number
+) => {
+    let nextTop = top;
+
+    for (let index = startIndex; index < endIndex; index += 1) {
+        rows.push({
+            type: 'track',
+            key: items[index],
+            id: items[index],
+            index,
+            tone,
+            top: nextTop,
+            height: QUEUE_TRACK_ROW_HEIGHT
+        });
+        nextTop += QUEUE_TRACK_ROW_HEIGHT;
+    }
+
+    return nextTop;
+};
+
+export const buildQueueVirtualLayout = (items: string[], currentIndex: number) => {
+    const rows: QueueVirtualRow[] = [];
+    let top = 0;
+
+    if (currentIndex > 0) {
+        top = appendSectionRow(rows, 'section-earlier', 'Earlier', top);
+        top = appendTrackRows(rows, items, 0, currentIndex, 'past', top);
+    }
+
+    if (currentIndex >= 0 && currentIndex < items.length) {
+        top = appendTrackRows(rows, items, currentIndex, currentIndex + 1, 'current', top);
+
+        if (currentIndex + 1 < items.length) {
+            top = appendSectionRow(rows, 'section-up-next', 'Up next', top);
+            top = appendTrackRows(rows, items, currentIndex + 1, items.length, 'upcoming', top);
+        }
+    } else if (items.length > 0) {
+        top = appendSectionRow(rows, 'section-queue', 'Queue', top);
+        top = appendTrackRows(rows, items, 0, items.length, 'upcoming', top);
+    }
+
+    return {
+        rows,
+        totalHeight: top
+    } satisfies QueueVirtualLayout;
+};
+
+export const getVisibleQueueVirtualRows = (
+    rows: QueueVirtualRow[],
+    scrollTop: number,
+    viewportHeight: number,
+    overscanPx = QUEUE_VIRTUAL_OVERSCAN_PX
+) => {
+    const safeScrollTop = Math.max(scrollTop, 0);
+    const safeViewportHeight = Math.max(viewportHeight, 0);
+    const rangeStart = Math.max(safeScrollTop - Math.max(overscanPx, 0), 0);
+    const rangeEnd = safeScrollTop + safeViewportHeight + Math.max(overscanPx, 0);
+
+    return rows.filter((row) => {
+        const rowBottom = row.top + row.height;
+        return rowBottom >= rangeStart && row.top <= rangeEnd;
+    });
+};
+
+export const findQueueTrackRow = (rows: QueueVirtualRow[], trackIndex: number) => {
+    return rows.find((row): row is QueueVirtualTrackRow => {
+        return row.type === 'track' && row.index === trackIndex;
+    }) ?? null;
+};
+
+export const getQueueTrackRows = (rows: QueueVirtualRow[]) => {
+    return rows.filter((row): row is QueueVirtualTrackRow => row.type === 'track');
+};
+
+export const findQueueDropSlot = (rows: QueueVirtualRow[], centerY: number) => {
+    const trackRows = getQueueTrackRows(rows);
+
+    if (trackRows.length === 0) {
+        return 0;
+    }
+
+    for (let slotIndex = 0; slotIndex < trackRows.length; slotIndex += 1) {
+        const row = trackRows[slotIndex];
+        const rowMidpoint = row.top + row.height / 2;
+
+        if (centerY < rowMidpoint) {
+            return slotIndex;
+        }
+    }
+
+    return trackRows.length;
+};
+
+export const getQueueDropIndicatorTop = (rows: QueueVirtualRow[], dropSlot: number) => {
+    const trackRows = getQueueTrackRows(rows);
+
+    if (trackRows.length === 0) {
+        return 0;
+    }
+
+    if (dropSlot <= 0) {
+        return trackRows[0].top + QUEUE_TRACK_ROW_GAP / 2;
+    }
+
+    if (dropSlot >= trackRows.length) {
+        const lastTrackRow = trackRows[trackRows.length - 1];
+        return lastTrackRow.top + lastTrackRow.height - QUEUE_TRACK_ROW_GAP / 2;
+    }
+
+    return trackRows[dropSlot].top;
+};
+
+export const resolveQueueDropIndex = (
+    trackCount: number,
+    activeIndex: number,
+    dropSlot: number
+) => {
+    if (trackCount <= 0) {
+        return 0;
+    }
+
+    const safeDropSlot = Math.min(Math.max(dropSlot, 0), trackCount);
+    const nextIndex = safeDropSlot > activeIndex
+        ? safeDropSlot - 1
+        : safeDropSlot;
+
+    return Math.min(Math.max(nextIndex, 0), trackCount - 1);
+};

--- a/server/src/client/src/pages/Player.tsx
+++ b/server/src/client/src/pages/Player.tsx
@@ -11,7 +11,7 @@ import { MusicPlayerDiskStyle, MusicPlayerFluffyStyle, MusicPlayerVisualizerStyl
 import { Text } from '~/components/shared';
 import * as Icon from '~/icon';
 
-import { useBack } from '~/hooks';
+import { useBack, useStoreValue } from '~/hooks';
 
 import { getImage } from '~/modules/image';
 import { makePlayTime } from '~/modules/time';
@@ -24,15 +24,22 @@ export default function PlayerDetail() {
     const back = useBack();
     const navigate = useNavigate();
 
-    const [state] = useStore(queueStore);
+    const [currentTrackId] = useStoreValue(queueStore, 'currentTrackId');
+    const [selected] = useStoreValue(queueStore, 'selected');
+    const [queueLength] = useStoreValue(queueStore, 'queueLength');
+    const [currentTime] = useStoreValue(queueStore, 'currentTime');
+    const [progress] = useStoreValue(queueStore, 'progress');
+    const [isPlaying] = useStoreValue(queueStore, 'isPlaying');
+    const [repeatMode] = useStoreValue(queueStore, 'repeatMode');
+    const [shuffle] = useStoreValue(queueStore, 'shuffle');
     const [{ playerAlbumArtStyle }] = useStore(themeStore);
     const [{ musicMap }] = useStore(musicStore);
 
-    const currentMusic = state.selected !== null
-        ? musicMap.get(state.items[state.selected])
+    const currentMusic = currentTrackId
+        ? musicMap.get(currentTrackId)
         : null;
     const duration = currentMusic?.duration || 0;
-    const queuePosition = state.selected !== null ? state.selected + 1 : null;
+    const queuePosition = selected !== null ? selected + 1 : null;
     const publishedYear = currentMusic?.album?.publishedYear?.trim() || '';
 
     // TODO: Fix type
@@ -71,12 +78,12 @@ export default function PlayerDetail() {
 
         if (e.key === 'ArrowLeft') {
             e.preventDefault();
-            queueStore.seek(Math.max(0, state.currentTime - 5));
+            queueStore.seek(Math.max(0, currentTime - 5));
         }
 
         if (e.key === 'ArrowRight') {
             e.preventDefault();
-            queueStore.seek(Math.min(duration, state.currentTime + 5));
+            queueStore.seek(Math.min(duration, currentTime + 5));
         }
 
         if (e.key === 'Home') {
@@ -118,14 +125,14 @@ export default function PlayerDetail() {
                             <div className={cx('album-art', { framed: showBackground })}>
                                 {playerAlbumArtStyle === '' && (
                                     <MusicPlayerFluffyStyle
-                                        isPlaying={state.isPlaying}
+                                        isPlaying={isPlaying}
                                         src={getImage(currentMusic.album.cover)}
                                         alt={currentMusic.album.name}
                                     />
                                 )}
                                 {playerAlbumArtStyle === 'disk' && (
                                     <MusicPlayerDiskStyle
-                                        isPlaying={state.isPlaying}
+                                        isPlaying={isPlaying}
                                         src={getImage(currentMusic.album.cover)}
                                         alt={currentMusic.album.name}
                                     />
@@ -133,7 +140,7 @@ export default function PlayerDetail() {
                                 {playerAlbumArtStyle.includes('visualizer') && (
                                     <MusicPlayerVisualizerStyle
                                         type={playerAlbumArtStyle.split(':')[1] || 'round'}
-                                        isPlaying={state.isPlaying}
+                                        isPlaying={isPlaying}
                                         src={getImage(currentMusic.album.cover)}
                                         alt={currentMusic.album.name}
                                     />
@@ -177,26 +184,26 @@ export default function PlayerDetail() {
                                 role="slider"
                                 tabIndex={duration > 0 ? 0 : -1}
                                 aria-label="Seek playback position"
-                                aria-valuenow={Math.round(state.currentTime)}
+                                aria-valuenow={Math.round(currentTime)}
                                 aria-valuemin={0}
                                 aria-valuemax={Math.round(duration)}
-                                aria-valuetext={`${makePlayTime(state.currentTime)} of ${makePlayTime(duration)}`}
+                                aria-valuetext={`${makePlayTime(currentTime)} of ${makePlayTime(duration)}`}
                                 onClick={handleClickProgress}
                                 onKeyDown={handleKeyDownProgress}
                                 onMouseMove={handleMoveProgress}
                                 onTouchMove={handleMoveProgress}>
                                 <div
                                     className={cx('bar')}
-                                    style={{ transform: `scaleX(${state.progress / 100})` }}
+                                    style={{ transform: `scaleX(${progress / 100})` }}
                                 />
                                 <div
                                     className={cx('thumb')}
-                                    style={{ left: `${state.progress}%` }}
+                                    style={{ left: `${progress}%` }}
                                 />
                             </div>
                             <div className={cx('time-info')}>
                                 <Text variant="tertiary" size="sm">
-                                    {makePlayTime(state.currentTime)}
+                                    {makePlayTime(currentTime)}
                                 </Text>
                                 <Text variant="tertiary" size="sm">
                                     {makePlayTime(duration)}
@@ -207,8 +214,8 @@ export default function PlayerDetail() {
                         <div className={cx('controls')}>
                             <button
                                 type="button"
-                                className={cx('control-button', { active: state.shuffle })}
-                                aria-label={state.shuffle ? 'Disable shuffle' : 'Enable shuffle'}
+                                className={cx('control-button', { active: shuffle })}
+                                aria-label={shuffle ? 'Disable shuffle' : 'Enable shuffle'}
                                 onClick={() => queueStore.toggleShuffle()}>
                                 <Icon.Shuffle />
                             </button>
@@ -224,9 +231,9 @@ export default function PlayerDetail() {
                             <button
                                 type="button"
                                 className={cx('play-button')}
-                                aria-label={state.isPlaying ? 'Pause playback' : 'Resume playback'}
-                                onClick={() => state.isPlaying ? queueStore.pause() : queueStore.play()}>
-                                {state.isPlaying ? <Icon.Pause /> : <Icon.Play />}
+                                aria-label={isPlaying ? 'Pause playback' : 'Resume playback'}
+                                onClick={() => isPlaying ? queueStore.pause() : queueStore.play()}>
+                                {isPlaying ? <Icon.Pause /> : <Icon.Play />}
                             </button>
 
                             <button
@@ -240,11 +247,11 @@ export default function PlayerDetail() {
                             <button
                                 type="button"
                                 className={cx('control-button')}
-                                aria-label={`Repeat mode ${state.repeatMode}`}
+                                aria-label={`Repeat mode ${repeatMode}`}
                                 onClick={() => queueStore.changeRepeatMode()}>
-                                {state.repeatMode === 'all' && <Icon.Repeat />}
-                                {state.repeatMode === 'one' && <Icon.Infinite />}
-                                {state.repeatMode === 'none' && <Icon.RightLeft />}
+                                {repeatMode === 'all' && <Icon.Repeat />}
+                                {repeatMode === 'one' && <Icon.Infinite />}
+                                {repeatMode === 'none' && <Icon.RightLeft />}
                             </button>
                         </div>
 
@@ -269,7 +276,7 @@ export default function PlayerDetail() {
                                     className={cx('secondary-action')}
                                     onClick={() => navigate('/queue')}>
                                     <Icon.ListMusic />
-                                    <span>Queue {queuePosition}/{state.items.length}</span>
+                                    <span>Queue {queuePosition}/{queueLength}</span>
                                 </button>
                             )}
                         </div>

--- a/server/src/client/src/pages/Queue.module.scss
+++ b/server/src/client/src/pages/Queue.module.scss
@@ -71,6 +71,13 @@
     flex-shrink: 0;
 }
 
+.top-bar-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
 .edit-button,
 .summary-action {
     min-height: 2.25rem;
@@ -187,6 +194,43 @@
     gap: 0.375rem;
 }
 
+.virtual-list {
+    position: relative;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.virtual-row {
+    position: absolute;
+    left: 0;
+    width: 100%;
+}
+
+.drag-source-hidden {
+    opacity: 0.16;
+}
+
+.drag-overlay {
+    z-index: 4;
+    pointer-events: none;
+    filter: drop-shadow(0 16px 24px rgba(2, 8, 11, 0.28));
+}
+
+.drop-indicator {
+    position: absolute;
+    left: 4.5rem;
+    right: 0.5rem;
+    height: 0.2rem;
+    margin-top: -0.1rem;
+    border-radius: var.$RADIUS_FULL;
+    background: rgba(193, 244, 251, 0.9);
+    box-shadow: 0 0 0 1px rgba(193, 244, 251, 0.16);
+    list-style: none;
+    pointer-events: none;
+    z-index: 3;
+}
+
 .section-label {
     padding: 0.625rem 0.25rem 0.125rem;
     color: var.$COLOR_TEXT_MUTED;
@@ -194,10 +238,16 @@
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
+    box-sizing: border-box;
 }
 
 .section-label-current {
     color: var.$COLOR_TEXT_TERTIARY;
+}
+
+.section-spacer {
+    pointer-events: none;
+    list-style: none;
 }
 
 .selection-actions {
@@ -318,6 +368,10 @@
 
     .top-bar {
         gap: 0.75rem;
+    }
+
+    .top-bar-actions {
+        gap: 0.375rem;
     }
 
     .section-label {

--- a/server/src/client/src/pages/Queue.tsx
+++ b/server/src/client/src/pages/Queue.tsx
@@ -2,21 +2,32 @@ import styles from './Queue.module.scss';
 import classNames from 'classnames/bind';
 const cx = classNames.bind(styles);
 
+import type {
+    CSSProperties,
+    PointerEvent as ReactPointerEvent
+} from 'react';
 import { useStore } from 'badland-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-
-import type { DragEndEvent } from '@dnd-kit/core';
-import { arrayMove } from '@dnd-kit/sortable';
-
-import { VerticalSortable } from '~/components/shared';
-import { Image, Text } from '~/components/shared';
+import { Text } from '~/components/shared';
 import { MusicActionPanelContent } from '~/components/music';
 import { PlaylistPanelContent } from '~/components/playlist';
 import * as Icon from '~/icon';
 
 import { panel } from '~/modules/panel';
 import { toast } from '~/modules/toast';
+import {
+    QUEUE_TRACK_CARD_HEIGHT,
+    QUEUE_TRACK_ROW_GAP,
+    QUEUE_VIRTUAL_OVERSCAN_PX,
+    buildQueueVirtualLayout,
+    findQueueDropSlot,
+    getQueueDropIndicatorTop,
+    getQueueTrackRows,
+    findQueueTrackRow,
+    getVisibleQueueVirtualRows,
+    resolveQueueDropIndex
+} from '~/modules/queue-virtual-rows';
 
 import type { Music } from '~/models/type';
 
@@ -24,80 +35,104 @@ import { PlaylistListener } from '~/socket';
 
 import { musicStore } from '~/store/music';
 import { queueStore } from '~/store/queue';
-import { useBack } from '~/hooks';
-import QueueDndItem, { type QueueTone } from './Queue/QueueDndItem';
+import { useBack, useStoreValue } from '~/hooks';
+import type { QueueTone } from './Queue/QueueDndItem';
+import QueueItem from './Queue/QueueItem';
+
+interface QueueDragState {
+    activeId: string;
+    activeIndex: number;
+    dropSlot: number;
+    grabOffsetY: number;
+    music: Music;
+    pointerClientY: number;
+    pointerContentY: number;
+    tone: QueueTone;
+}
 
 export default function Queue() {
     const back = useBack();
     const navigate = useNavigate();
 
-    const [{ items, selected }, setState] = useStore(queueStore);
+    const [items] = useStoreValue(queueStore, 'items');
+    const [selected] = useStoreValue(queueStore, 'selected');
     const [{ musicMap }] = useStore(musicStore);
 
+    const scrollRef = useRef<HTMLDivElement>(null);
     const listRef = useRef<HTMLDivElement>(null);
     const [isSelectMode, setIsSelectMode] = useState(false);
+    const [listViewport, setListViewport] = useState({
+        scrollTop: 0,
+        height: 0
+    });
     const [selectedItems, setSelectedItems] = useState<string[]>([]);
+    const [dragState, setDragState] = useState<QueueDragState | null>(null);
+    const dragStateRef = useRef<QueueDragState | null>(null);
+    const dragListenersCleanupRef = useRef<(() => void) | null>(null);
 
     const currentIndex = selected ?? -1;
-    const currentMusic = currentIndex >= 0
-        ? musicMap.get(items[currentIndex]) ?? null
-        : null;
-    const nextMusic = currentIndex >= 0
-        ? currentIndex + 1 < items.length
-            ? musicMap.get(items[currentIndex + 1]) ?? null
-            : null
-        : items.length > 0
-            ? musicMap.get(items[0]) ?? null
-            : null;
+    const queueSummary = currentIndex >= 0
+        ? `${currentIndex + 1} of ${items.length} · ${Math.max(items.length - currentIndex - 1, 0)} up next`
+        : `${items.length} tracks in session`;
 
-    const previousEntries = currentIndex > 0
-        ? items.slice(0, currentIndex).map((id, index) => ({
-            id,
-            index
-        }))
-        : [];
-    const currentEntry = currentIndex >= 0
-        ? {
-            id: items[currentIndex],
-            index: currentIndex
+    const virtualLayout = useMemo(() => {
+        return buildQueueVirtualLayout(items, currentIndex);
+    }, [currentIndex, items]);
+    const trackRows = useMemo(() => {
+        return getQueueTrackRows(virtualLayout.rows);
+    }, [virtualLayout.rows]);
+    const virtualRowsRef = useRef(virtualLayout.rows);
+    const trackRowsRef = useRef(trackRows);
+    const visibleVirtualRows = useMemo(() => {
+        return getVisibleQueueVirtualRows(
+            virtualLayout.rows,
+            listViewport.scrollTop,
+            listViewport.height,
+            QUEUE_VIRTUAL_OVERSCAN_PX
+        );
+    }, [listViewport.height, listViewport.scrollTop, virtualLayout.rows]);
+    const selectedVirtualRow = useMemo(() => {
+        if (selected === null) {
+            return null;
         }
+
+        return findQueueTrackRow(virtualLayout.rows, selected);
+    }, [selected, virtualLayout.rows]);
+    const dragIndicatorTop = dragState
+        ? getQueueDropIndicatorTop(virtualLayout.rows, dragState.dropSlot)
         : null;
-    const upcomingStart = currentIndex >= 0 ? currentIndex + 1 : 0;
-    const upcomingEntries = items
-        .slice(upcomingStart)
-        .map((id, offset) => ({
-            id,
-            index: upcomingStart + offset
-        }));
+    const dragOverlayTop = dragState
+        ? dragState.pointerContentY - dragState.grabOffsetY
+        : null;
 
-    const handleDragEnd = async (event: DragEndEvent) => {
-        const { active, over } = event;
+    const cleanupDragSession = () => {
+        dragListenersCleanupRef.current?.();
+        dragListenersCleanupRef.current = null;
+        dragStateRef.current = null;
+        setDragState(null);
+    };
 
-        if (!over || active.id === over.id) {
+    const syncDragPointer = (
+        pointerClientY: number,
+        meta: Pick<QueueDragState, 'activeId' | 'activeIndex' | 'grabOffsetY' | 'music' | 'tone'>
+    ) => {
+        const listNode = listRef.current;
+
+        if (!listNode) {
             return;
         }
 
-        setState((prevState) => {
-            const prevSelectedItem = prevState.selected !== null
-                ? prevState.items[prevState.selected]
-                : null;
-            const oldIndex = prevState.items.indexOf(active.id.toString());
-            const newIndex = prevState.items.indexOf(over.id.toString());
-            const newItems = arrayMove(prevState.items, oldIndex, newIndex);
+        const pointerContentY = pointerClientY - listNode.getBoundingClientRect().top;
+        const dragCenterY = pointerContentY - meta.grabOffsetY + QUEUE_TRACK_CARD_HEIGHT / 2;
+        const nextDragState = {
+            ...meta,
+            pointerClientY,
+            pointerContentY,
+            dropSlot: findQueueDropSlot(virtualRowsRef.current, dragCenterY)
+        } satisfies QueueDragState;
 
-            if (prevSelectedItem) {
-                return {
-                    ...prevState,
-                    items: newItems,
-                    selected: newItems.indexOf(prevSelectedItem)
-                };
-            }
-
-            return {
-                ...prevState,
-                items: newItems
-            };
-        });
+        dragStateRef.current = nextDragState;
+        setDragState(nextDragState);
     };
 
     useEffect(() => {
@@ -105,25 +140,170 @@ export default function Queue() {
     }, [isSelectMode]);
 
     useEffect(() => {
+        virtualRowsRef.current = virtualLayout.rows;
+        trackRowsRef.current = trackRows;
+    }, [trackRows, virtualLayout.rows]);
+
+    useEffect(() => {
+        dragStateRef.current = dragState;
+    }, [dragState]);
+
+    useEffect(() => {
         setSelectedItems((prev) => prev.filter((id) => items.includes(id)));
     }, [items]);
 
     useEffect(() => {
-        if (selected === null || !listRef.current) {
+        if (isSelectMode) {
+            cleanupDragSession();
+        }
+    }, [isSelectMode]);
+
+    useEffect(() => {
+        return () => {
+            dragListenersCleanupRef.current?.();
+        };
+    }, []);
+
+    useEffect(() => {
+        const scrollNode = scrollRef.current;
+        const listNode = listRef.current;
+
+        if (!scrollNode || !listNode) {
             return;
         }
 
-        const targetElement = listRef.current.querySelector<HTMLElement>(`[data-queue-index="${selected}"]`);
+        let animationFrameId = 0;
 
-        if (!targetElement) {
-            return;
-        }
+        const updateViewport = () => {
+            animationFrameId = 0;
 
-        listRef.current.scrollTo({
-            top: Math.max(0, targetElement.offsetTop - 80),
-            behavior: 'smooth'
+            const containerRect = scrollNode.getBoundingClientRect();
+            const listRect = listNode.getBoundingClientRect();
+            const visibleTop = Math.max(containerRect.top, listRect.top);
+            const visibleBottom = Math.min(containerRect.bottom, listRect.bottom);
+
+            setListViewport({
+                scrollTop: Math.max(containerRect.top - listRect.top, 0),
+                height: Math.max(visibleBottom - visibleTop, 0)
+            });
+        };
+
+        const scheduleViewportUpdate = () => {
+            if (animationFrameId !== 0) {
+                return;
+            }
+
+            animationFrameId = window.requestAnimationFrame(updateViewport);
+        };
+
+        scheduleViewportUpdate();
+
+        scrollNode.addEventListener('scroll', scheduleViewportUpdate, { passive: true });
+
+        const resizeObserver = new ResizeObserver(() => {
+            scheduleViewportUpdate();
         });
-    }, [selected]);
+
+        resizeObserver.observe(scrollNode);
+        resizeObserver.observe(listNode);
+
+        return () => {
+            scrollNode.removeEventListener('scroll', scheduleViewportUpdate);
+            resizeObserver.disconnect();
+
+            if (animationFrameId !== 0) {
+                window.cancelAnimationFrame(animationFrameId);
+            }
+        };
+    }, [items.length, isSelectMode]);
+
+    useEffect(() => {
+        const scrollNode = scrollRef.current;
+
+        if (selected === null || !scrollNode) {
+            return;
+        }
+
+        const containerRect = scrollNode.getBoundingClientRect();
+        const listNode = listRef.current;
+
+        if (!listNode) {
+            return;
+        }
+
+        if (!selectedVirtualRow) {
+            return;
+        }
+
+        const listRect = listNode.getBoundingClientRect();
+        const nextTop = Math.max(
+            0,
+            scrollNode.scrollTop + listRect.top - containerRect.top + selectedVirtualRow.top - 80
+        );
+        const travelDistance = Math.abs(nextTop - scrollNode.scrollTop);
+        const behavior = travelDistance > Math.max(containerRect.height * 1.5, 480)
+            ? 'auto'
+            : 'smooth';
+
+        scrollNode.scrollTo({
+            top: nextTop,
+            behavior
+        });
+    }, [selectedVirtualRow?.top]);
+
+    useEffect(() => {
+        if (!dragState) {
+            return;
+        }
+
+        let animationFrameId = 0;
+        const scrollNode = scrollRef.current;
+
+        if (!scrollNode) {
+            return;
+        }
+
+        const stepAutoScroll = () => {
+            const activeDragState = dragStateRef.current;
+
+            if (!activeDragState) {
+                return;
+            }
+
+            const containerRect = scrollNode.getBoundingClientRect();
+            const threshold = 72;
+            const maxStep = 18;
+            let delta = 0;
+
+            if (activeDragState.pointerClientY < containerRect.top + threshold) {
+                const progress = 1 - (activeDragState.pointerClientY - containerRect.top) / threshold;
+                delta = -Math.ceil(Math.max(progress, 0) * maxStep);
+            } else if (activeDragState.pointerClientY > containerRect.bottom - threshold) {
+                const progress = 1 - (containerRect.bottom - activeDragState.pointerClientY) / threshold;
+                delta = Math.ceil(Math.max(progress, 0) * maxStep);
+            }
+
+            if (delta !== 0) {
+                const nextScrollTop = Math.min(
+                    Math.max(scrollNode.scrollTop + delta, 0),
+                    scrollNode.scrollHeight - scrollNode.clientHeight
+                );
+
+                if (nextScrollTop !== scrollNode.scrollTop) {
+                    scrollNode.scrollTop = nextScrollTop;
+                    syncDragPointer(activeDragState.pointerClientY, activeDragState);
+                }
+            }
+
+            animationFrameId = window.requestAnimationFrame(stepAutoScroll);
+        };
+
+        animationFrameId = window.requestAnimationFrame(stepAutoScroll);
+
+        return () => {
+            window.cancelAnimationFrame(animationFrameId);
+        };
+    }, [dragState]);
 
     const openMusicActions = (music: Music) => {
         panel.open({
@@ -137,38 +317,175 @@ export default function Queue() {
         });
     };
 
+    const startReorderDrag = (
+        id: string,
+        index: number,
+        tone: QueueTone,
+        music: Music
+    ) => (event: ReactPointerEvent<HTMLButtonElement>) => {
+        if (isSelectMode || event.button !== 0) {
+            return;
+        }
+
+        const rowNode = event.currentTarget.closest('[data-queue-index]');
+
+        if (!(rowNode instanceof HTMLElement)) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const rowRect = rowNode.getBoundingClientRect();
+        const meta = {
+            activeId: id,
+            activeIndex: index,
+            grabOffsetY: event.clientY - rowRect.top,
+            music,
+            tone
+        };
+
+        syncDragPointer(event.clientY, meta);
+
+        const handlePointerMove = (moveEvent: PointerEvent) => {
+            moveEvent.preventDefault();
+            syncDragPointer(moveEvent.clientY, meta);
+        };
+
+        const finishDrag = () => {
+            const activeDragState = dragStateRef.current;
+
+            cleanupDragSession();
+
+            if (!activeDragState) {
+                return;
+            }
+
+            const targetIndex = resolveQueueDropIndex(
+                trackRowsRef.current.length,
+                activeDragState.activeIndex,
+                activeDragState.dropSlot
+            );
+
+            queueStore.reorderToIndex(activeDragState.activeId, targetIndex);
+        };
+
+        const cancelDrag = () => {
+            cleanupDragSession();
+        };
+
+        window.addEventListener('pointermove', handlePointerMove, { passive: false });
+        window.addEventListener('pointerup', finishDrag, { once: true });
+        window.addEventListener('pointercancel', cancelDrag, { once: true });
+
+        dragListenersCleanupRef.current = () => {
+            window.removeEventListener('pointermove', handlePointerMove);
+            window.removeEventListener('pointerup', finishDrag);
+            window.removeEventListener('pointercancel', cancelDrag);
+        };
+    };
+
     const toggleSelectedItem = (id: string) => {
         setSelectedItems((prev) => prev.includes(id)
             ? prev.filter((item) => item !== id)
             : [...prev, id]);
     };
 
-    const renderQueueItem = (id: string, index: number, tone: QueueTone) => {
+    const renderQueueItem = (
+        id: string,
+        index: number,
+        tone: QueueTone,
+        options?: {
+            className?: string;
+            style?: CSSProperties;
+        }
+    ) => {
         const music = musicMap.get(id);
 
         if (!music) {
             return null;
         }
 
+        const sharedProps = {
+            key: id,
+            music,
+            index,
+            tone,
+            isSelectMode,
+            className: options?.className,
+            isSelected: selectedItems.includes(id),
+            onSelect: () => toggleSelectedItem(id),
+            onClick: () => {
+                queueStore.select(index);
+            },
+            onOpenActions: () => openMusicActions(music),
+            onReorderPointerDown: startReorderDrag(id, index, tone, music),
+            style: options?.style
+        };
+
         return (
-            <QueueDndItem
-                key={id}
-                music={music}
-                index={index}
-                tone={tone}
-                isSelectMode={isSelectMode}
-                isSelected={selectedItems.includes(id)}
-                onSelect={() => toggleSelectedItem(id)}
-                onClick={() => {
-                    queueStore.select(index);
-                }}
-                onOpenActions={() => openMusicActions(music)}
+            <QueueItem
+                {...sharedProps}
             />
         );
     };
 
+    const renderVirtualRows = () => {
+        return (
+            <>
+                {visibleVirtualRows.map((row) => {
+                    if (row.type === 'section') {
+                        return (
+                            <li
+                                key={row.key}
+                                className={cx('virtual-row', 'section-label', { 'section-label-current': row.current })}
+                                style={{
+                                    top: `${row.top}px`,
+                                    height: `${row.height}px`
+                                }}>
+                                {row.label}
+                            </li>
+                        );
+                    }
+
+                    return renderQueueItem(row.id, row.index, row.tone, {
+                        className: cx('virtual-row', { 'drag-source-hidden': dragState?.activeId === row.id }),
+                        style: {
+                            top: `${row.top + QUEUE_TRACK_ROW_GAP / 2}px`,
+                            height: `${QUEUE_TRACK_CARD_HEIGHT}px`
+                        }
+                    });
+                })}
+                {dragIndicatorTop !== null && (
+                    <li
+                        className={cx('drop-indicator')}
+                        style={{ top: `${dragIndicatorTop}px` }}
+                    />
+                )}
+                {dragState && dragOverlayTop !== null && (
+                    <QueueItem
+                        key={`drag-overlay-${dragState.activeId}`}
+                        className={cx('virtual-row', 'drag-overlay')}
+                        music={dragState.music}
+                        index={dragState.activeIndex}
+                        tone={dragState.tone}
+                        isSelectMode={false}
+                        isSelected={false}
+                        onSelect={() => {}}
+                        onClick={() => {}}
+                        onOpenActions={() => {}}
+                        style={{
+                            top: `${dragOverlayTop}px`,
+                            height: `${QUEUE_TRACK_CARD_HEIGHT}px`
+                        }}
+                    />
+                )}
+            </>
+        );
+    };
+
     return (
-        <div className={cx('Queue')}>
+        <div className={cx('Queue')} ref={scrollRef}>
             <div className={cx('container')}>
                 <div className={cx('top-bar')}>
                     <button
@@ -186,97 +503,14 @@ export default function Queue() {
                         <Text as="p" variant="muted" size="xs">
                             {isSelectMode
                                 ? `${selectedItems.length} selected`
-                                : `${items.length} tracks in session`}
+                                : queueSummary}
                         </Text>
                     </div>
 
                     {items.length > 0 ? (
-                        <button
-                            type="button"
-                            className={cx('edit-button', { active: isSelectMode })}
-                            onClick={() => setIsSelectMode((prev) => !prev)}>
-                            {isSelectMode ? 'Done' : 'Edit'}
-                        </button>
-                    ) : (
-                        <div className={cx('top-bar-spacer')} />
-                    )}
-                </div>
-
-                {items.length > 0 ? (
-                    <>
-                        <section className={cx('overview')}>
-                            <div className={cx('overview-header')}>
-                                <Text
-                                    as="span"
-                                    variant="muted"
-                                    size="xs"
-                                    weight="medium"
-                                    className={cx('eyebrow')}>
-                                    {currentMusic ? 'Now playing' : 'Queue overview'}
-                                </Text>
-                                <div className={cx('overview-stats')}>
-                                    <span>{currentMusic ? `${currentIndex + 1} / ${items.length}` : `${items.length} queued`}</span>
-                                    <span>{currentMusic ? `${Math.max(items.length - currentIndex - 1, 0)} up next` : 'Ready to start'}</span>
-                                </div>
-                            </div>
-
-                            {currentMusic ? (
-                                <div className={cx('overview-track')}>
-                                    <Image
-                                        className={cx('overview-art')}
-                                        src={currentMusic.album.cover}
-                                        alt={currentMusic.album.name}
-                                        loading="eager"
-                                    />
-                                    <div className={cx('overview-copy')}>
-                                        <Text as="h2" size="xl" weight="bold" className={cx('overview-title')}>
-                                            {currentMusic.name}
-                                        </Text>
-                                        <Text as="p" variant="secondary" size="md">
-                                            {currentMusic.artist.name}
-                                        </Text>
-                                        <Text as="p" variant="tertiary" size="sm">
-                                            {currentMusic.album.name}
-                                        </Text>
-                                    </div>
-                                </div>
-                            ) : nextMusic ? (
-                                <div className={cx('overview-track')}>
-                                    <Image
-                                        className={cx('overview-art')}
-                                        src={nextMusic.album.cover}
-                                        alt={nextMusic.album.name}
-                                        loading="eager"
-                                    />
-                                    <div className={cx('overview-copy')}>
-                                        <Text as="h2" size="xl" weight="bold" className={cx('overview-title')}>
-                                            {nextMusic.name}
-                                        </Text>
-                                        <Text as="p" variant="secondary" size="md">
-                                            {nextMusic.artist.name}
-                                        </Text>
-                                        <Text as="p" variant="tertiary" size="sm">
-                                            Waiting at the front of the queue
-                                        </Text>
-                                    </div>
-                                </div>
-                            ) : null}
-
-                            <Text as="p" variant="secondary" size="sm" className={cx('overview-note')}>
-                                {nextMusic && currentMusic
-                                    ? `Up next: ${nextMusic.name} by ${nextMusic.artist.name}`
-                                    : currentMusic
-                                        ? 'This is the last track in the current session.'
-                                        : nextMusic
-                                            ? `${nextMusic.name} is first in line.`
-                                            : 'Choose a track from your library to begin listening.'}
-                            </Text>
-
-                            {isSelectMode && (
-                                <div className={cx('selection-summary')}>
-                                    <Text as="span" variant="secondary" size="sm">
-                                        Select tracks to save or remove them together.
-                                    </Text>
+                        <div className={cx('top-bar-actions')}>
+                            {isSelectMode ? (
+                                <>
                                     <button
                                         type="button"
                                         className={cx('summary-action')}
@@ -284,32 +518,34 @@ export default function Queue() {
                                         onClick={() => setSelectedItems(items)}>
                                         Select all
                                     </button>
-                                </div>
+                                    <button
+                                        type="button"
+                                        className={cx('edit-button', { active: true })}
+                                        onClick={() => setIsSelectMode(false)}>
+                                        Done
+                                    </button>
+                                </>
+                            ) : (
+                                <button
+                                    type="button"
+                                    className={cx('edit-button')}
+                                    onClick={() => setIsSelectMode(true)}>
+                                    Edit
+                                </button>
                             )}
-                        </section>
+                        </div>
+                    ) : (
+                        <div className={cx('top-bar-spacer')} />
+                    )}
+                </div>
 
+                {items.length > 0 ? (
+                    <>
                         <div className={cx('list-shell')} ref={listRef}>
-                            <ul className={cx('list')}>
-                                <VerticalSortable items={items} onDragEnd={handleDragEnd}>
-                                    {previousEntries.length > 0 && (
-                                        <li className={cx('section-label')}>Earlier</li>
-                                    )}
-                                    {previousEntries.map(({ id, index }) => renderQueueItem(id, index, 'past'))}
-
-                                    {currentEntry && (
-                                        <li className={cx('section-label', 'section-label-current')}>
-                                            Now playing
-                                        </li>
-                                    )}
-                                    {currentEntry && renderQueueItem(currentEntry.id, currentEntry.index, 'current')}
-
-                                    {upcomingEntries.length > 0 && (
-                                        <li className={cx('section-label')}>
-                                            {currentEntry ? 'Up next' : 'Queue'}
-                                        </li>
-                                    )}
-                                    {upcomingEntries.map(({ id, index }) => renderQueueItem(id, index, 'upcoming'))}
-                                </VerticalSortable>
+                            <ul
+                                className={cx('virtual-list')}
+                                style={{ height: `${virtualLayout.totalHeight}px` }}>
+                                {renderVirtualRows()}
                             </ul>
                         </div>
                     </>

--- a/server/src/client/src/pages/Queue/QueueDndItem.module.scss
+++ b/server/src/client/src/pages/Queue/QueueDndItem.module.scss
@@ -4,6 +4,7 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    min-height: 4.875rem;
     border-radius: 1rem;
     border: 1px solid transparent;
     background: rgba(238, 249, 252, 0.02);
@@ -26,18 +27,30 @@
     }
 }
 
+@supports (content-visibility: auto) {
+    .item {
+        content-visibility: auto;
+        contain-intrinsic-size: 4.875rem;
+    }
+}
+
 .leading-button,
-.row-action {
+.row-action,
+.leading-index {
     width: 2.5rem;
     height: 2.5rem;
-    border: none;
     border-radius: var.$RADIUS_FULL;
-    background: transparent;
     color: var.$COLOR_TEXT_MUTED;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
+}
+
+.leading-button,
+.row-action {
+    border: none;
+    background: transparent;
     transition: var.$TRANSITION_FAST;
     transition-property: color, background-color;
 
@@ -50,6 +63,14 @@
         color: var.$COLOR_TEXT;
         background: rgba(238, 249, 252, 0.08);
     }
+}
+
+.leading-index {
+    margin-left: 0.25rem;
+    background: rgba(238, 249, 252, 0.04);
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
 }
 
 .leading-button {
@@ -67,6 +88,7 @@
 
 .drag-handle {
     cursor: grab;
+    touch-action: none;
 }
 
 .row-button {
@@ -133,6 +155,7 @@
 @media (max-width: 640px) {
     .item {
         gap: 0.375rem;
+        min-height: 4.625rem;
     }
 
     .row-button {

--- a/server/src/client/src/pages/Queue/QueueItem.tsx
+++ b/server/src/client/src/pages/Queue/QueueItem.tsx
@@ -1,0 +1,120 @@
+import type {
+    ButtonHTMLAttributes,
+    CSSProperties
+} from 'react';
+
+import styles from './QueueDndItem.module.scss';
+import classNames from 'classnames/bind';
+const cx = classNames.bind(styles);
+
+import { Image, Text } from '~/components/shared';
+import * as Icon from '~/icon';
+
+import type { Music } from '~/models/type';
+
+import type { QueueTone } from './QueueDndItem';
+
+interface QueueItemProps {
+    className?: string;
+    music: Music;
+    index: number;
+    tone: QueueTone;
+    isSelectMode: boolean;
+    isSelected: boolean;
+    onSelect: () => void;
+    onClick: () => void;
+    onOpenActions: () => void;
+    onReorderPointerDown?: ButtonHTMLAttributes<HTMLButtonElement>['onPointerDown'];
+    style?: CSSProperties;
+}
+
+export default function QueueItem({
+    className,
+    music,
+    index,
+    tone,
+    isSelectMode,
+    isSelected,
+    onSelect,
+    onClick,
+    onOpenActions,
+    onReorderPointerDown,
+    style
+}: QueueItemProps) {
+    return (
+        <li
+            data-queue-index={index}
+            style={style}
+            className={cx('item', tone, className, { selected: isSelected })}>
+            {isSelectMode ? (
+                <button
+                    type="button"
+                    className={cx('leading-button', { active: isSelected })}
+                    aria-label={isSelected ? `Unselect ${music.name}` : `Select ${music.name}`}
+                    aria-pressed={isSelected}
+                    onClick={onSelect}>
+                    <Icon.CheckBox />
+                </button>
+            ) : (
+                <button
+                    type="button"
+                    className={cx('leading-button', 'drag-handle')}
+                    aria-label={`Reorder ${music.name}`}
+                    onPointerDown={onReorderPointerDown}>
+                    <Icon.Menu />
+                </button>
+            )}
+
+            <button
+                type="button"
+                className={cx('row-button')}
+                onClick={isSelectMode ? onSelect : onClick}
+                onContextMenu={(e) => {
+                    e.preventDefault();
+
+                    if (!isSelectMode) {
+                        onOpenActions();
+                    }
+                }}>
+                <Image
+                    className={cx('cover')}
+                    src={music.album.cover}
+                    alt={music.album.name}
+                />
+
+                <div className={cx('copy')}>
+                    <div className={cx('title-line')}>
+                        <Text
+                            as="span"
+                            size="md"
+                            weight={tone === 'current' ? 'semibold' : 'medium'}
+                            className={cx('title')}>
+                            {music.name}
+                        </Text>
+                        {tone === 'current' && (
+                            <span className={cx('current-pill')}>Now</span>
+                        )}
+                    </div>
+
+                    <Text as="span" variant="secondary" size="sm" className={cx('meta')}>
+                        {music.artist.name}
+                    </Text>
+
+                    <Text as="span" variant="tertiary" size="sm" className={cx('submeta')}>
+                        {music.album.name}
+                    </Text>
+                </div>
+            </button>
+
+            {!isSelectMode && (
+                <button
+                    type="button"
+                    className={cx('row-action')}
+                    aria-label={`Open actions for ${music.name}`}
+                    onClick={onOpenActions}>
+                    <Icon.VerticalDots />
+                </button>
+            )}
+        </li>
+    );
+}

--- a/server/src/client/src/store/queue.ts
+++ b/server/src/client/src/store/queue.ts
@@ -10,6 +10,12 @@ import {
 } from '~/modules/audio-channel';
 import { confirm } from '~/modules/confirm';
 import { getNextSelectedIndexAfterRemovingCurrent } from '~/modules/queue-selection';
+import {
+    deriveQueueState,
+    deriveQueueStateFromTrack,
+    moveQueueItemToIndex,
+    reorderQueueItems
+} from '~/modules/queue-state';
 import { toast } from '~/modules/toast';
 import { convertToMillisecond } from '~/modules/time';
 import { PlaybackSessionTracker } from '~/modules/playback-session';
@@ -18,6 +24,8 @@ import { shuffle } from '~/modules/shuffle';
 
 interface QueueStoreState {
     selected: number | null;
+    currentTrackId: string | null;
+    queueLength: number;
     isPlaying: boolean;
     shuffle: boolean;
     insertMode: 'first' | 'last' | 'after';
@@ -35,6 +43,11 @@ const getMusic = (id: string) => {
     return musicMap.get(id);
 };
 
+const createQueueState = (items: string[], selected: number | null) => ({
+    items,
+    ...deriveQueueState(items, selected)
+});
+
 class QueueStore extends Store<QueueStoreState> {
     saveTimer: ReturnType<typeof setTimeout> | null = null;
     audioChannel: AudioChannel;
@@ -46,6 +59,8 @@ class QueueStore extends Store<QueueStoreState> {
         this.playbackSessionTracker = new PlaybackSessionTracker();
         this.state = {
             selected: null,
+            currentTrackId: null,
+            queueLength: 0,
             isPlaying: false,
             shuffle: false,
             insertMode: 'last',
@@ -60,11 +75,11 @@ class QueueStore extends Store<QueueStoreState> {
 
         const audioChannelEventHandler: AudioChannelEventHandler = {
             onPlay: () => {
-                if (this.state.selected === null) {
+                if (!this.state.currentTrackId) {
                     return;
                 }
 
-                const currentMusic = getMusic(this.state.items[this.state.selected]);
+                const currentMusic = getMusic(this.state.currentTrackId);
 
                 if (currentMusic) {
                     this.playbackSessionTracker.play({
@@ -110,7 +125,9 @@ class QueueStore extends Store<QueueStoreState> {
                 }
             },
             onTimeUpdate: (time, mix) => {
-                const music = getMusic(this.state.items[this.state.selected!]);
+                const music = this.state.currentTrackId
+                    ? getMusic(this.state.currentTrackId)
+                    : undefined;
                 const progress = Number((time / (music?.duration || 1) * 100).toFixed(2));
 
                 if (this.state.mixMode === 'mix') {
@@ -139,9 +156,33 @@ class QueueStore extends Store<QueueStoreState> {
             if (loaded) {
                 const queue = localStorage.getItem('queue');
                 if (queue) {
-                    const nextState = JSON.parse(queue) as QueueStoreState;
-                    await this.set(nextState);
-                    this.select(nextState.selected || 0, false);
+                    const persistedState = JSON.parse(queue) as Partial<QueueStoreState>;
+                    const restoredItems = Array.isArray(persistedState.items)
+                        ? persistedState.items
+                        : [];
+                    const restoredSelected = typeof persistedState.selected === 'number'
+                        ? persistedState.selected
+                        : null;
+                    const restoredQueueState = createQueueState(restoredItems, restoredSelected);
+
+                    await this.set({
+                        ...restoredQueueState,
+                        isPlaying: false,
+                        shuffle: persistedState.shuffle ?? false,
+                        insertMode: persistedState.insertMode ?? 'last',
+                        repeatMode: persistedState.repeatMode ?? 'none',
+                        playMode: persistedState.playMode ?? 'later',
+                        mixMode: persistedState.mixMode ?? 'none',
+                        currentTime: 0,
+                        progress: 0,
+                        sourceItems: Array.isArray(persistedState.sourceItems)
+                            ? persistedState.sourceItems
+                            : []
+                    });
+
+                    if (restoredQueueState.selected !== null) {
+                        this.select(restoredQueueState.selected, false);
+                    }
                 }
                 musicStore.unsubscribe(key);
             }
@@ -179,10 +220,9 @@ class QueueStore extends Store<QueueStoreState> {
         this.commitPlaybackEvent('queue-reset');
 
         await this.set({
-            items: ids,
+            ...createQueueState(ids, null),
             sourceItems: [],
             shuffle: false,
-            selected: null,
             currentTime: 0,
             progress: 0,
             isPlaying: false
@@ -199,34 +239,46 @@ class QueueStore extends Store<QueueStoreState> {
             toast('Already added to queue');
             return;
         }
+
+        const currentTrackId = this.state.currentTrackId;
+        let nextItems = this.state.items;
+        let nextSourceItems = this.state.sourceItems;
+
         if (this.state.shuffle) {
-            this.set({ sourceItems: [...this.state.items, id] });
+            nextSourceItems = [...this.state.items, id];
         }
         if (this.state.insertMode === 'first') {
-            this.set({ items: [id, ...this.state.items] });
+            nextItems = [id, ...this.state.items];
         }
         if (this.state.insertMode === 'last') {
-            this.set({ items: [...this.state.items, id] });
+            nextItems = [...this.state.items, id];
         }
         if (this.state.insertMode === 'after') {
             if (this.state.selected === null) {
-                this.set({ items: [...this.state.items, id] });
+                nextItems = [...this.state.items, id];
             } else {
-                this.set({
-                    items: [
-                        ...this.state.items.slice(0, this.state.selected + 1),
-                        id,
-                        ...this.state.items.slice(this.state.selected + 1)
-                    ]
-                });
+                nextItems = [
+                    ...this.state.items.slice(0, this.state.selected + 1),
+                    id,
+                    ...this.state.items.slice(this.state.selected + 1)
+                ];
             }
         }
+
+        const nextQueueState = deriveQueueStateFromTrack(nextItems, currentTrackId);
+
+        this.set({
+            ...nextQueueState,
+            items: nextItems,
+            sourceItems: nextSourceItems
+        });
+
         toast('Added to queue');
         if (this.state.playMode === 'immediately') {
-            this.select(this.state.items.indexOf(id));
+            this.select(nextItems.indexOf(id));
             return;
         }
-        if (this.state.selected === null) {
+        if (nextQueueState.selected === null) {
             this.select(0);
         }
     }
@@ -236,15 +288,14 @@ class QueueStore extends Store<QueueStoreState> {
         const newSourceItems = this.state.sourceItems.filter((i) => !ids.includes(i));
 
         const prevSelected = this.state.selected;
-        const prevSelectedItem = newItems.length > 0
-            ? this.state.items[prevSelected || 0]
-            : null;
+        const prevSelectedItem = this.state.currentTrackId;
 
         if (prevSelectedItem && ids.includes(prevSelectedItem)) {
             this.commitPlaybackEvent('queue-remove');
         }
 
         await this.set({
+            ...deriveQueueStateFromTrack(newItems, prevSelectedItem),
             items: newItems,
             sourceItems: newSourceItems
         });
@@ -252,7 +303,6 @@ class QueueStore extends Store<QueueStoreState> {
         if (newItems.length === 0) {
             this.audioChannel.stop();
             this.set({
-                selected: null,
                 currentTime: 0,
                 progress: 0,
                 isPlaying: false
@@ -262,7 +312,6 @@ class QueueStore extends Store<QueueStoreState> {
 
         if (prevSelectedItem) {
             if (!ids.includes(prevSelectedItem)) {
-                this.set({ selected: newItems.indexOf(prevSelectedItem) });
                 return;
             }
             if (ids.includes(prevSelectedItem)) {
@@ -278,14 +327,18 @@ class QueueStore extends Store<QueueStoreState> {
     select(index: number, play = true) {
         this.commitPlaybackEvent('queue-track-change');
 
+        const nextQueueState = createQueueState(this.state.items, index);
+
         this.set({
-            selected: index,
+            ...nextQueueState,
             progress: 0,
             currentTime: 0,
             isPlaying: play
         });
 
-        const music = getMusic(this.state.items[index]);
+        const music = nextQueueState.currentTrackId
+            ? getMusic(nextQueueState.currentTrackId)
+            : undefined;
         if (music === undefined) return;
 
         document.title = `${music.name} - ${music.artist.name}`;
@@ -332,14 +385,46 @@ class QueueStore extends Store<QueueStoreState> {
         this.set({ repeatMode: next });
     }
 
+    reorder(activeId: string, overId: string) {
+        const nextItems = reorderQueueItems(this.state.items, activeId, overId);
+
+        if (nextItems === this.state.items) {
+            return;
+        }
+
+        this.set({
+            ...deriveQueueStateFromTrack(nextItems, this.state.currentTrackId),
+            items: nextItems
+        });
+    }
+
+    reorderToIndex(activeId: string, targetIndex: number) {
+        const nextItems = moveQueueItemToIndex(this.state.items, activeId, targetIndex);
+
+        if (nextItems === this.state.items) {
+            return;
+        }
+
+        this.set({
+            ...deriveQueueStateFromTrack(nextItems, this.state.currentTrackId),
+            items: nextItems
+        });
+    }
+
     toggleShuffle() {
-        const selectedMusic = this.state.items[this.state.selected!];
+        const selectedMusic = this.state.currentTrackId;
+
+        if (!selectedMusic) {
+            return;
+        }
 
         if (this.state.shuffle) {
+            const nextItems = [...this.state.sourceItems];
+
             this.set({
                 shuffle: false,
-                selected: this.state.sourceItems.indexOf(selectedMusic),
-                items: [...this.state.sourceItems],
+                ...deriveQueueStateFromTrack(nextItems, selectedMusic),
+                items: nextItems,
                 sourceItems: []
             });
             return;
@@ -352,7 +437,7 @@ class QueueStore extends Store<QueueStoreState> {
 
         this.set({
             shuffle: true,
-            selected: 0,
+            ...deriveQueueStateFromTrack(newItems, selectedMusic),
             items: newItems,
             sourceItems: [...this.state.items]
         });


### PR DESCRIPTION
## :dart: Goal

Improve large-queue responsiveness in Ocean Wave while keeping drag reorder available in the default queue surface.

## :hammer_and_wrench: Core Changes

- Added queue-derived state helpers and a typed `useStoreValue` hook so the player surfaces subscribe only to the queue fields they actually need.
- Reworked the queue page into a virtualized list that renders only visible rows plus overscan and jumps long-distance current-track scrolls instead of animating through the full list.
- Replaced the old full-list sortable path with lightweight drag reorder on the default queue surface using a drag handle, overlay, and drop indicator.
- Simplified the queue UI by removing the large top overview block, keeping direct queue summary text, and preserving `Edit` mode only for multi-select actions.

## :brain: Key Decisions

- Kept the queue performance work centered on rendering cost, not just DnD visuals; the critical change is avoiding per-row sortable registration for large queues.
- Left reorder available by default because the virtualized drag path now performs well enough on both desktop and mobile.
- Kept the current-track highlighting in-row and removed redundant `Now playing` chrome at the top of the queue.

## :test_tube: Verification Guide

- `cd server/src/client && pnpm test -- --runInBand src/modules/queue-virtual-rows.test.ts src/modules/queue-state.test.ts src/modules/queue-selection.test.ts`
Expected: `10 passed`, `33 passed`.
- `cd server/src/client && pnpm build`
Expected: build succeeds.
- `cd server/src/client && pnpm lint`
Expected: lint succeeds with no warnings.

## :white_check_mark: Checklist

- [x] Local validation for the changed scope is complete.
- [x] No docs, scripts, or env changes need PR-body follow-up.
- [x] PR title uses the required `<emoji> <subject>` format.
