### PR TITLE
✨ Add track identity sync flow

### DIFF
--- a/server/src/prisma/migrations/20260409144000_0004_track_identity_foundation/migration.sql
+++ b/server/src/prisma/migrations/20260409144000_0004_track_identity_foundation/migration.sql
@@ -1,0 +1,12 @@
+-- AlterTable
+ALTER TABLE "Music" ADD COLUMN "contentHash" TEXT;
+ALTER TABLE "Music" ADD COLUMN "hashVersion" INTEGER;
+ALTER TABLE "Music" ADD COLUMN "lastSeenAt" DATETIME;
+ALTER TABLE "Music" ADD COLUMN "missingSinceAt" DATETIME;
+ALTER TABLE "Music" ADD COLUMN "syncStatus" TEXT NOT NULL DEFAULT 'active';
+
+-- CreateIndex
+CREATE INDEX "Music_contentHash_idx" ON "Music"("contentHash");
+
+-- CreateIndex
+CREATE INDEX "Music_syncStatus_missingSinceAt_idx" ON "Music"("syncStatus", "missingSinceAt");

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -49,6 +49,8 @@ model Music {
     albumId       Int
     artistId      Int
     filePath      String
+    contentHash   String?
+    hashVersion   Int?
     duration      Float
     codec         String
     container     String
@@ -56,6 +58,9 @@ model Music {
     sampleRate    Float
     playCount     Int             @default(0)
     lastPlayedAt  DateTime?
+    lastSeenAt    DateTime?
+    missingSinceAt DateTime?
+    syncStatus    String          @default("active")
     totalPlayedMs Float           @default(0)
     trackNumber   Int
     Genre         Genre[]
@@ -63,6 +68,9 @@ model Music {
     MusicHate     MusicHate[]
     PlaybackEvent PlaybackEvent[]
     PlaylistMusic PlaylistMusic[]
+
+    @@index([contentHash])
+    @@index([syncStatus, missingSinceAt])
 }
 
 model PlaybackEvent {

--- a/server/src/src/modules/track-hash.ts
+++ b/server/src/src/modules/track-hash.ts
@@ -1,0 +1,17 @@
+import crypto from 'crypto';
+
+export const TRACK_CONTENT_HASH_VERSION = 1;
+
+export const createTrackContentHash = (data: Buffer) => {
+    return crypto.createHash('sha256').update(data).digest('hex');
+};
+
+export const shouldRefreshTrackContentHash = ({
+    contentHash,
+    hashVersion
+}: {
+    contentHash: string | null;
+    hashVersion: number | null;
+}) => {
+    return !contentHash || hashVersion !== TRACK_CONTENT_HASH_VERSION;
+};

--- a/server/src/src/modules/track-identity.test.ts
+++ b/server/src/src/modules/track-identity.test.ts
@@ -1,0 +1,130 @@
+import {
+    TRACK_SYNC_STATUS,
+    classifyTrackIdentityCandidate,
+    deriveTrackPresenceUpdates,
+    type TrackIdentityRecord
+} from './track-identity';
+
+const createRecord = (overrides?: Partial<TrackIdentityRecord>): TrackIdentityRecord => {
+    return {
+        id: overrides?.id ?? 1,
+        filePath: overrides?.filePath ?? 'library/track-a.mp3',
+        contentHash: overrides?.contentHash ?? 'hash-a',
+        lastSeenAt: overrides?.lastSeenAt ?? null,
+        missingSinceAt: overrides?.missingSinceAt ?? null,
+        syncStatus: overrides?.syncStatus ?? TRACK_SYNC_STATUS.active
+    };
+};
+
+describe('track identity', () => {
+    it('classifies an exact file path as a path match before looking at hashes', () => {
+        const record = createRecord({
+            filePath: 'library/exact.mp3',
+            contentHash: null
+        });
+
+        expect(classifyTrackIdentityCandidate(
+            [record],
+            {
+                filePath: 'library/exact.mp3',
+                contentHash: 'new-hash'
+            },
+            new Set(['library/exact.mp3'])
+        )).toEqual({
+            kind: 'path-match',
+            record
+        });
+    });
+
+    it('classifies a new path with a missing old hash match as a moved track', () => {
+        const record = createRecord({
+            id: 7,
+            filePath: 'old/location.mp3',
+            contentHash: 'same-hash'
+        });
+
+        expect(classifyTrackIdentityCandidate(
+            [record],
+            {
+                filePath: 'new/location.mp3',
+                contentHash: 'same-hash'
+            },
+            new Set(['new/location.mp3'])
+        )).toEqual({
+            kind: 'moved',
+            record
+        });
+    });
+
+    it('classifies a new path with an existing visible hash match as a duplicate', () => {
+        const record = createRecord({
+            id: 9,
+            filePath: 'library/original.mp3',
+            contentHash: 'same-hash'
+        });
+
+        expect(classifyTrackIdentityCandidate(
+            [record],
+            {
+                filePath: 'library/copy.mp3',
+                contentHash: 'same-hash'
+            },
+            new Set(['library/original.mp3', 'library/copy.mp3'])
+        )).toEqual({
+            kind: 'duplicate',
+            record
+        });
+    });
+
+    it('classifies a candidate with no known hash match as a new track', () => {
+        expect(classifyTrackIdentityCandidate(
+            [createRecord()],
+            {
+                filePath: 'library/new.mp3',
+                contentHash: 'hash-new'
+            },
+            new Set(['library/new.mp3'])
+        )).toEqual({ kind: 'new' });
+    });
+
+    it('marks unseen active tracks as missing and preserves the first missing timestamp', () => {
+        const observedAt = new Date('2026-04-09T12:00:00.000Z');
+        const firstMissingAt = new Date('2026-04-08T12:00:00.000Z');
+
+        expect(deriveTrackPresenceUpdates(
+            [
+                createRecord({
+                    id: 1,
+                    filePath: 'library/seen.mp3',
+                    lastSeenAt: null
+                }),
+                createRecord({
+                    id: 2,
+                    filePath: 'library/unseen.mp3',
+                    lastSeenAt: null
+                }),
+                createRecord({
+                    id: 3,
+                    filePath: 'library/already-missing.mp3',
+                    syncStatus: TRACK_SYNC_STATUS.missing,
+                    missingSinceAt: firstMissingAt
+                })
+            ],
+            new Set(['library/seen.mp3']),
+            observedAt
+        )).toEqual([
+            {
+                id: 1,
+                lastSeenAt: observedAt,
+                missingSinceAt: null,
+                syncStatus: TRACK_SYNC_STATUS.active
+            },
+            {
+                id: 2,
+                lastSeenAt: null,
+                missingSinceAt: observedAt,
+                syncStatus: TRACK_SYNC_STATUS.missing
+            }
+        ]);
+    });
+});

--- a/server/src/src/modules/track-identity.test.ts
+++ b/server/src/src/modules/track-identity.test.ts
@@ -2,6 +2,7 @@ import {
     TRACK_SYNC_STATUS,
     classifyTrackIdentityCandidate,
     deriveTrackPresenceUpdates,
+    resolveVisibleTrackSyncStatus,
     type TrackIdentityRecord
 } from './track-identity';
 
@@ -126,5 +127,28 @@ describe('track identity', () => {
                 syncStatus: TRACK_SYNC_STATUS.missing
             }
         ]);
+    });
+
+    it('promotes the lowest visible hash match to active and keeps later copies duplicate', () => {
+        const original = createRecord({
+            id: 2,
+            filePath: 'library/copy-a.mp3',
+            contentHash: 'same-hash',
+            syncStatus: TRACK_SYNC_STATUS.duplicate
+        });
+        const laterCopy = createRecord({
+            id: 5,
+            filePath: 'library/copy-b.mp3',
+            contentHash: 'same-hash',
+            syncStatus: TRACK_SYNC_STATUS.duplicate
+        });
+        const visiblePaths = new Set([original.filePath, laterCopy.filePath]);
+
+        expect(resolveVisibleTrackSyncStatus([original, laterCopy], original, visiblePaths)).toBe(
+            TRACK_SYNC_STATUS.active
+        );
+        expect(resolveVisibleTrackSyncStatus([original, laterCopy], laterCopy, visiblePaths)).toBe(
+            TRACK_SYNC_STATUS.duplicate
+        );
     });
 });

--- a/server/src/src/modules/track-identity.ts
+++ b/server/src/src/modules/track-identity.ts
@@ -33,6 +33,34 @@ export interface TrackPresenceUpdate {
     syncStatus: TrackSyncStatus;
 }
 
+const sortByLowestId = (records: TrackIdentityRecord[]) => {
+    return [...records].sort((left, right) => left.id - right.id);
+};
+
+export const resolveVisibleTrackSyncStatus = (
+    records: TrackIdentityRecord[],
+    record: TrackIdentityRecord,
+    visiblePaths: Set<string>
+) => {
+    if (!record.contentHash) {
+        return TRACK_SYNC_STATUS.active;
+    }
+
+    const visibleHashMatches = records.filter((candidate) => {
+        return candidate.contentHash === record.contentHash && visiblePaths.has(candidate.filePath);
+    });
+
+    if (visibleHashMatches.length <= 1) {
+        return TRACK_SYNC_STATUS.active;
+    }
+
+    const primaryVisibleId = sortByLowestId(visibleHashMatches)[0].id;
+
+    return record.id === primaryVisibleId
+        ? TRACK_SYNC_STATUS.active
+        : TRACK_SYNC_STATUS.duplicate;
+};
+
 export const classifyTrackIdentityCandidate = (
     records: TrackIdentityRecord[],
     candidate: TrackIdentityCandidate,
@@ -51,7 +79,7 @@ export const classifyTrackIdentityCandidate = (
         return { kind: 'new' };
     }
 
-    const hashMatches = records.filter((record) => record.contentHash === candidate.contentHash);
+    const hashMatches = sortByLowestId(records.filter((record) => record.contentHash === candidate.contentHash));
 
     if (hashMatches.length === 0) {
         return { kind: 'new' };
@@ -83,7 +111,7 @@ export const deriveTrackPresenceUpdates = (
                 id: record.id,
                 lastSeenAt: observedAt,
                 missingSinceAt: null,
-                syncStatus: TRACK_SYNC_STATUS.active
+                syncStatus: resolveVisibleTrackSyncStatus(records, record, visiblePaths)
             }];
         }
 

--- a/server/src/src/modules/track-identity.ts
+++ b/server/src/src/modules/track-identity.ts
@@ -1,0 +1,101 @@
+export const TRACK_SYNC_STATUS = {
+    active: 'active',
+    missing: 'missing',
+    duplicate: 'duplicate'
+} as const;
+
+export type TrackSyncStatus = typeof TRACK_SYNC_STATUS[keyof typeof TRACK_SYNC_STATUS];
+
+export interface TrackIdentityRecord {
+    id: number;
+    filePath: string;
+    contentHash: string | null;
+    lastSeenAt: Date | null;
+    missingSinceAt: Date | null;
+    syncStatus: TrackSyncStatus;
+}
+
+export interface TrackIdentityCandidate {
+    filePath: string;
+    contentHash: string | null;
+}
+
+export type TrackIdentityMatch =
+    | { kind: 'path-match'; record: TrackIdentityRecord }
+    | { kind: 'moved'; record: TrackIdentityRecord }
+    | { kind: 'duplicate'; record: TrackIdentityRecord }
+    | { kind: 'new' };
+
+export interface TrackPresenceUpdate {
+    id: number;
+    lastSeenAt: Date | null;
+    missingSinceAt: Date | null;
+    syncStatus: TrackSyncStatus;
+}
+
+export const classifyTrackIdentityCandidate = (
+    records: TrackIdentityRecord[],
+    candidate: TrackIdentityCandidate,
+    visiblePaths: Set<string>
+): TrackIdentityMatch => {
+    const pathMatch = records.find((record) => record.filePath === candidate.filePath);
+
+    if (pathMatch) {
+        return {
+            kind: 'path-match',
+            record: pathMatch
+        };
+    }
+
+    if (!candidate.contentHash) {
+        return { kind: 'new' };
+    }
+
+    const hashMatches = records.filter((record) => record.contentHash === candidate.contentHash);
+
+    if (hashMatches.length === 0) {
+        return { kind: 'new' };
+    }
+
+    const movedMatch = hashMatches.find((record) => !visiblePaths.has(record.filePath));
+
+    if (movedMatch) {
+        return {
+            kind: 'moved',
+            record: movedMatch
+        };
+    }
+
+    return {
+        kind: 'duplicate',
+        record: hashMatches[0]
+    };
+};
+
+export const deriveTrackPresenceUpdates = (
+    records: TrackIdentityRecord[],
+    visiblePaths: Set<string>,
+    observedAt: Date
+) => {
+    return records.flatMap<TrackPresenceUpdate>((record) => {
+        if (visiblePaths.has(record.filePath)) {
+            return [{
+                id: record.id,
+                lastSeenAt: observedAt,
+                missingSinceAt: null,
+                syncStatus: TRACK_SYNC_STATUS.active
+            }];
+        }
+
+        if (record.syncStatus === TRACK_SYNC_STATUS.missing) {
+            return [];
+        }
+
+        return [{
+            id: record.id,
+            lastSeenAt: record.lastSeenAt,
+            missingSinceAt: record.missingSinceAt ?? observedAt,
+            syncStatus: TRACK_SYNC_STATUS.missing
+        }];
+    });
+};

--- a/server/src/src/schema/album/index.ts
+++ b/server/src/src/schema/album/index.ts
@@ -2,6 +2,7 @@ import type { IResolvers } from '@graphql-tools/utils';
 
 import models, { type Album } from '~/models';
 import { gql } from '~/modules/graphql';
+import { TRACK_SYNC_STATUS } from '~/modules/track-identity';
 import { artistType } from '../artist';
 import { musicType } from '../music';
 
@@ -35,13 +36,19 @@ export const albumTypeDefs = `
 
 export const albumResolvers: IResolvers = {
     Query: {
-        allAlbums: () => models.album.findMany({ orderBy: { name: 'asc' } }),
+        allAlbums: () => models.album.findMany({
+            where: { Music: { some: { syncStatus: TRACK_SYNC_STATUS.active } } },
+            orderBy: { name: 'asc' }
+        }),
         album: (_, { id }: Album) => models.album.findUnique({ where: { id: Number(id) } })
     },
     Album: {
         artist: (album: Album) => models.artist.findUnique({ where: { id: album.artistId } }),
         musics: (album: Album) => models.music.findMany({
-            where: { Album: { id: album.id } },
+            where: {
+                Album: { id: album.id },
+                syncStatus: TRACK_SYNC_STATUS.active
+            },
             orderBy: { trackNumber: 'asc' }
         })
     }

--- a/server/src/src/schema/artist/index.ts
+++ b/server/src/src/schema/artist/index.ts
@@ -2,6 +2,7 @@ import type { IResolvers } from '@graphql-tools/utils';
 
 import models, { type Artist } from '~/models';
 import { gql } from '~/modules/graphql';
+import { TRACK_SYNC_STATUS } from '~/modules/track-identity';
 import { albumType } from '../album';
 import { musicType } from '../music';
 
@@ -36,23 +37,45 @@ export const artistTypeDefs = `
 
 export const artistResolvers: IResolvers = {
     Query: {
-        allArtists: () => models.artist.findMany({ orderBy: { Music: { _count: 'desc' } } }),
+        allArtists: () => models.artist.findMany({
+            where: { Music: { some: { syncStatus: TRACK_SYNC_STATUS.active } } },
+            orderBy: { Music: { _count: 'desc' } }
+        }),
         artist: (_, { id }: Artist) => models.artist.findUnique({ where: { id: Number(id) } })
     },
     Artist: {
         latestAlbum: (artist: Artist) => models.album.findFirst({
-            where: { artistId: artist.id },
+            where: {
+                artistId: artist.id,
+                Music: { some: { syncStatus: TRACK_SYNC_STATUS.active } }
+            },
             orderBy: { publishedYear: 'desc' }
         }),
         albums: (artist: Artist) => models.album.findMany({
-            where: { artistId: artist.id },
+            where: {
+                artistId: artist.id,
+                Music: { some: { syncStatus: TRACK_SYNC_STATUS.active } }
+            },
             orderBy: { publishedYear: 'desc' }
         }),
         musics: (artist: Artist) => models.music.findMany({
-            where: { artistId: artist.id },
+            where: {
+                artistId: artist.id,
+                syncStatus: TRACK_SYNC_STATUS.active
+            },
             orderBy: { playCount: 'desc' }
         }),
-        albumCount: (artist: Artist) => models.album.count({ where: { artistId: artist.id } }),
-        musicCount: (artist: Artist) => models.music.count({ where: { artistId: artist.id } })
+        albumCount: (artist: Artist) => models.album.count({
+            where: {
+                artistId: artist.id,
+                Music: { some: { syncStatus: TRACK_SYNC_STATUS.active } }
+            }
+        }),
+        musicCount: (artist: Artist) => models.music.count({
+            where: {
+                artistId: artist.id,
+                syncStatus: TRACK_SYNC_STATUS.active
+            }
+        })
     }
 };

--- a/server/src/src/schema/music/index.ts
+++ b/server/src/src/schema/music/index.ts
@@ -2,6 +2,7 @@ import type { IResolvers } from '@graphql-tools/utils';
 
 import models, { type Music } from '~/models';
 import { gql } from '~/modules/graphql';
+import { TRACK_SYNC_STATUS } from '~/modules/track-identity';
 import { artistType } from '../artist';
 import { albumType } from '../album';
 
@@ -51,7 +52,10 @@ export const musicTypeDefs = `
 
 export const musicResolvers: IResolvers = {
     Query: {
-        allMusics: () => models.music.findMany({ orderBy: { playCount: 'desc' } }),
+        allMusics: () => models.music.findMany({
+            where: { syncStatus: TRACK_SYNC_STATUS.active },
+            orderBy: { playCount: 'desc' }
+        }),
         music: (_, { id }: Music) => models.music.findUnique({ where: { id: Number(id) } })
     },
     Music: {

--- a/server/src/src/schema/playlist/index.ts
+++ b/server/src/src/schema/playlist/index.ts
@@ -2,6 +2,7 @@ import type { IResolvers } from '@graphql-tools/utils';
 
 import models, { type Playlist } from '~/models';
 import { gql } from '~/modules/graphql';
+import { TRACK_SYNC_STATUS } from '~/modules/track-identity';
 import { musicType } from '../music';
 
 export const playlistType = gql`
@@ -43,7 +44,10 @@ export const playlistResolvers: IResolvers = {
     Playlist: {
         musics: async (playlist: Playlist) => {
             const musics = await models.playlistMusic.findMany({
-                where: { playlistId: playlist.id },
+                where: {
+                    playlistId: playlist.id,
+                    Music: { syncStatus: TRACK_SYNC_STATUS.active }
+                },
                 orderBy: { order: 'asc' },
                 include: { Music: true }
             });
@@ -51,13 +55,21 @@ export const playlistResolvers: IResolvers = {
         },
         headerMusics: async (playlist: Playlist) => {
             const musics = await models.playlistMusic.findMany({
-                where: { playlistId: playlist.id },
+                where: {
+                    playlistId: playlist.id,
+                    Music: { syncStatus: TRACK_SYNC_STATUS.active }
+                },
                 orderBy: { order: 'asc' },
                 include: { Music: true },
                 take: 4
             });
             return musics.map((playlistMusic) => playlistMusic.Music);
         },
-        musicCount: (playlist: Playlist) => models.music.count({ where: { PlaylistMusic: { some: { playlistId: playlist.id } } } })
+        musicCount: (playlist: Playlist) => models.music.count({
+            where: {
+                PlaylistMusic: { some: { playlistId: playlist.id } },
+                syncStatus: TRACK_SYNC_STATUS.active
+            }
+        })
     }
 };

--- a/server/src/src/socket/sync.test.ts
+++ b/server/src/src/socket/sync.test.ts
@@ -1,0 +1,282 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parseBuffer } from 'music-metadata';
+
+import models from '~/models';
+import { musicResolvers } from '~/schema/music';
+
+jest.mock('../modules/file', () => ({ walk: jest.fn() }));
+
+jest.mock('music-metadata', () => ({ parseBuffer: jest.fn() }));
+
+jest.mock('sharp', () => {
+    return jest.fn(() => ({
+        resize: jest.fn().mockReturnThis(),
+        toFile: jest.fn().mockResolvedValue(undefined)
+    }));
+});
+
+import { walk } from '../modules/file';
+import { TRACK_CONTENT_HASH_VERSION, createTrackContentHash } from '../modules/track-hash';
+import { TRACK_SYNC_STATUS } from '../modules/track-identity';
+import { syncMusic } from './sync';
+
+const walkMock = jest.mocked(walk);
+const parseBufferMock = jest.mocked(parseBuffer);
+
+const createTrackFixture = (overrides?: {
+    title?: string;
+    artist?: string;
+    album?: string;
+    year?: string;
+    trackNumber?: number;
+    fingerprint?: string;
+}) => {
+    const title = overrides?.title ?? 'Track A';
+    const artist = overrides?.artist ?? 'Artist A';
+    const album = overrides?.album ?? 'Album A';
+    const year = overrides?.year ?? '2026';
+    const trackNumber = overrides?.trackNumber ?? 1;
+    const fingerprint = overrides?.fingerprint ?? 'fingerprint-a';
+
+    return `title=${title}|artist=${artist}|album=${album}|year=${year}|track=${trackNumber}|fingerprint=${fingerprint}`;
+};
+
+const createTempTrackFile = ({
+    directory,
+    relativePath,
+    contents
+}: {
+    directory: string;
+    relativePath: string;
+    contents: string;
+}) => {
+    const absolutePath = path.join(directory, relativePath);
+
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, contents);
+
+    return absolutePath;
+};
+
+const createExistingMusic = async ({
+    filePath,
+    contents,
+    syncStatus = TRACK_SYNC_STATUS.active,
+    withHash = true
+}: {
+    filePath: string;
+    contents: string;
+    syncStatus?: typeof TRACK_SYNC_STATUS[keyof typeof TRACK_SYNC_STATUS];
+    withHash?: boolean;
+}) => {
+    const artist = await models.artist.create({ data: { name: 'Artist A' } });
+    const album = await models.album.create({
+        data: {
+            name: 'Album A',
+            cover: '',
+            publishedYear: '2026',
+            artistId: artist.id
+        }
+    });
+
+    return models.music.create({
+        data: {
+            name: 'Track A',
+            artistId: artist.id,
+            albumId: album.id,
+            filePath,
+            contentHash: withHash ? createTrackContentHash(Buffer.from(contents)) : null,
+            hashVersion: withHash ? TRACK_CONTENT_HASH_VERSION : null,
+            duration: 180,
+            codec: 'mp3',
+            container: 'mp3',
+            bitrate: 320,
+            sampleRate: 44100,
+            trackNumber: 1,
+            syncStatus
+        }
+    });
+};
+
+describe('sync music identity', () => {
+    const tempDirectories: string[] = [];
+
+    beforeEach(async () => {
+        jest.restoreAllMocks();
+        walkMock.mockReset();
+        parseBufferMock.mockReset();
+        parseBufferMock.mockImplementation(async (data) => {
+            const entries = Object.fromEntries(
+                data.toString().split('|').map((entry) => entry.split('='))
+            );
+
+            return {
+                format: {
+                    container: 'mp3',
+                    codec: 'mp3',
+                    bitrate: 320,
+                    duration: 180,
+                    sampleRate: 44100
+                },
+                common: {
+                    title: entries.title,
+                    artist: entries.artist,
+                    album: entries.album,
+                    genre: [],
+                    year: Number(entries.year),
+                    track: { no: Number(entries.track) }
+                }
+            } as never;
+        });
+
+        await models.playbackEvent.deleteMany();
+        await models.playlistMusic.deleteMany();
+        await models.playlist.deleteMany();
+        await models.musicLike.deleteMany();
+        await models.musicHate.deleteMany();
+        await models.music.deleteMany();
+        await models.album.deleteMany();
+        await models.artist.deleteMany();
+        await models.genre.deleteMany();
+    });
+
+    afterEach(() => {
+        while (tempDirectories.length > 0) {
+            fs.rmSync(tempDirectories.pop()!, {
+                recursive: true,
+                force: true
+            });
+        }
+
+        fs.rmSync(path.resolve('./cache'), {
+            recursive: true,
+            force: true
+        });
+    });
+
+    it('moves a track to a new path without losing linked data', async () => {
+        const contents = createTrackFixture();
+        const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'beato-sync-move-'));
+        tempDirectories.push(tempDirectory);
+
+        const movedPath = createTempTrackFile({
+            directory: tempDirectory,
+            relativePath: 'library/new/track-a.mp3',
+            contents
+        });
+        const existingMusic = await createExistingMusic({
+            filePath: path.join(tempDirectory, 'library/old/track-a.mp3'),
+            contents
+        });
+        const playlist = await models.playlist.create({ data: { name: 'Favorites' } });
+        await models.musicLike.create({ data: { musicId: existingMusic.id } });
+        await models.playlistMusic.create({
+            data: {
+                playlistId: playlist.id,
+                musicId: existingMusic.id
+            }
+        });
+
+        walkMock.mockResolvedValue([movedPath]);
+
+        const result = await syncMusic({ emit: jest.fn() } as never);
+        const movedMusic = await models.music.findUniqueOrThrow({ where: { id: existingMusic.id } });
+        const like = await models.musicLike.findFirst({ where: { musicId: existingMusic.id } });
+        const playlistLink = await models.playlistMusic.findFirst({ where: { musicId: existingMusic.id } });
+
+        expect(result).toMatchObject({
+            moved: [{
+                musicId: existingMusic.id,
+                filePath: movedPath
+            }]
+        });
+        expect(movedMusic.filePath).toBe(movedPath);
+        expect(movedMusic.syncStatus).toBe(TRACK_SYNC_STATUS.active);
+        expect(movedMusic.missingSinceAt).toBeNull();
+        expect(like).not.toBeNull();
+        expect(playlistLink).not.toBeNull();
+    });
+
+    it('creates a duplicate row but keeps the normal library scoped to active tracks', async () => {
+        const contents = createTrackFixture({ fingerprint: 'duplicate-hash' });
+        const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'beato-sync-duplicate-'));
+        tempDirectories.push(tempDirectory);
+
+        const originalPath = createTempTrackFile({
+            directory: tempDirectory,
+            relativePath: 'library/original/track-a.mp3',
+            contents
+        });
+        const copyPath = createTempTrackFile({
+            directory: tempDirectory,
+            relativePath: 'library/copy/track-a.mp3',
+            contents
+        });
+        const originalMusic = await createExistingMusic({
+            filePath: originalPath,
+            contents,
+            withHash: false
+        });
+
+        walkMock.mockResolvedValue([originalPath, copyPath]);
+
+        const result = await syncMusic({ emit: jest.fn() } as never);
+        const musics = await models.music.findMany({ orderBy: { id: 'asc' } });
+        const visibleMusics = await (musicResolvers.Query as { allMusics: () => Promise<{ id: number }[]> }).allMusics();
+
+        expect(result).toMatchObject({
+            duplicate: [{
+                musicId: musics[1].id,
+                filePath: copyPath
+            }]
+        });
+        expect(musics).toHaveLength(2);
+        expect(musics[0]).toMatchObject({
+            id: originalMusic.id,
+            filePath: originalPath,
+            syncStatus: TRACK_SYNC_STATUS.active
+        });
+        expect(musics[0].contentHash).toBe(createTrackContentHash(Buffer.from(contents)));
+        expect(musics[1]).toMatchObject({
+            filePath: copyPath,
+            syncStatus: TRACK_SYNC_STATUS.duplicate
+        });
+        expect(visibleMusics.map((music) => music.id)).toEqual([originalMusic.id]);
+    });
+
+    it('marks unseen tracks as missing instead of deleting them', async () => {
+        const contents = createTrackFixture({ fingerprint: 'missing-hash' });
+        const existingMusic = await createExistingMusic({
+            filePath: '/tmp/library/missing-track.mp3',
+            contents
+        });
+        const playlist = await models.playlist.create({ data: { name: 'Archive' } });
+        await models.musicLike.create({ data: { musicId: existingMusic.id } });
+        await models.playlistMusic.create({
+            data: {
+                playlistId: playlist.id,
+                musicId: existingMusic.id
+            }
+        });
+
+        walkMock.mockResolvedValue([]);
+
+        const result = await syncMusic({ emit: jest.fn() } as never);
+        const missingMusic = await models.music.findUniqueOrThrow({ where: { id: existingMusic.id } });
+        const visibleMusics = await (musicResolvers.Query as { allMusics: () => Promise<{ id: number }[]> }).allMusics();
+
+        expect(result).toMatchObject({
+            missing: [{
+                musicId: existingMusic.id,
+                filePath: existingMusic.filePath
+            }]
+        });
+        expect(missingMusic.syncStatus).toBe(TRACK_SYNC_STATUS.missing);
+        expect(missingMusic.missingSinceAt).not.toBeNull();
+        expect(await models.musicLike.count({ where: { musicId: existingMusic.id } })).toBe(1);
+        expect(await models.playlistMusic.count({ where: { musicId: existingMusic.id } })).toBe(1);
+        expect(visibleMusics).toHaveLength(0);
+    });
+});

--- a/server/src/src/socket/sync.ts
+++ b/server/src/src/socket/sync.ts
@@ -7,19 +7,352 @@ import sharp from 'sharp';
 import { connectors } from './connectors';
 
 import { walk } from '../modules/file';
+import {
+    TRACK_CONTENT_HASH_VERSION,
+    createTrackContentHash,
+    shouldRefreshTrackContentHash
+} from '../modules/track-hash';
+import {
+    TRACK_SYNC_STATUS,
+    classifyTrackIdentityCandidate,
+    deriveTrackPresenceUpdates,
+    type TrackIdentityRecord,
+    type TrackSyncStatus
+} from '../modules/track-identity';
 
-import models from '~/models';
+import models, { type Album, type Artist, type Genre, type Music } from '~/models';
+
+const SUPPORTED_AUDIO_EXTENSIONS = new Set([
+    '.mp3',
+    '.aac',
+    '.wav',
+    '.ogg',
+    '.flac'
+]);
+
+const SYNC_EVENT = 'sync-music';
+
+interface ParsedTrackMetadata {
+    title: string;
+    albumArtist: string | null;
+    artist: string;
+    album: string;
+    pictureData: Buffer | null;
+    genres: string[];
+    year: string;
+    trackNumber: number;
+    codec: string;
+    container: string;
+    bitrate: number;
+    duration: number;
+    sampleRate: number;
+}
+
+interface SyncResultEntry {
+    musicId: number;
+    filePath: string;
+}
+
+export interface SyncMusicResult {
+    scannedFiles: number;
+    indexedFiles: number;
+    created: SyncResultEntry[];
+    moved: SyncResultEntry[];
+    duplicate: SyncResultEntry[];
+    missing: SyncResultEntry[];
+}
+
+const ensureDirectory = (directoryPath: string) => {
+    if (!fs.existsSync(directoryPath)) {
+        fs.mkdirSync(directoryPath, { recursive: true });
+    }
+};
+
+const emitSyncMessage = (socket: Pick<Socket, 'emit'>, message: string) => {
+    socket.emit(SYNC_EVENT, message);
+};
+
+const isSupportedAudioFile = (filePath: string) => {
+    return SUPPORTED_AUDIO_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+};
+
+const toTrackIdentityRecord = (music: Music): TrackIdentityRecord => {
+    return {
+        id: music.id,
+        filePath: music.filePath,
+        contentHash: music.contentHash,
+        lastSeenAt: music.lastSeenAt,
+        missingSinceAt: music.missingSinceAt,
+        syncStatus: music.syncStatus as TrackSyncStatus
+    };
+};
+
+const parseTrackMetadata = async (filePath: string, data: Buffer): Promise<ParsedTrackMetadata> => {
+    const { format, common } = await parseBuffer(data);
+    const {
+        container = '',
+        codec = '',
+        bitrate = 0,
+        duration = 0,
+        sampleRate = 0
+    } = format;
+    const {
+        title = path.parse(filePath).name,
+        albumartist: albumArtist = null,
+        artist = 'unknown',
+        album = 'unknown',
+        picture,
+        genre = [],
+        year = (new Date()).getFullYear(),
+        track
+    } = common;
+
+    return {
+        title,
+        albumArtist,
+        artist,
+        album,
+        pictureData: picture?.[0]?.data ?? null,
+        genres: genre,
+        year: year.toString(),
+        trackNumber: track?.no || 1,
+        codec,
+        container,
+        bitrate,
+        duration,
+        sampleRate
+    };
+};
+
+const findOrCreateArtist = async (name: string): Promise<Artist> => {
+    const existingArtist = await models.artist.findFirst({ where: { name } });
+
+    if (existingArtist) {
+        return existingArtist;
+    }
+
+    return models.artist.create({ data: { name } });
+};
+
+const findOrCreateAlbum = async ({
+    name,
+    publishedYear,
+    artistId
+}: {
+    name: string;
+    publishedYear: string;
+    artistId: number;
+}): Promise<Album> => {
+    const existingAlbum = await models.album.findFirst({
+        where: {
+            name,
+            artistId
+        }
+    });
+
+    if (existingAlbum) {
+        return existingAlbum;
+    }
+
+    return models.album.create({
+        data: {
+            name,
+            cover: '',
+            publishedYear,
+            artistId
+        }
+    });
+};
+
+const findOrCreateGenres = async (genreNames: string[]): Promise<Genre[]> => {
+    return Promise.all(genreNames.map(async (name) => {
+        const existingGenre = await models.genre.findUnique({ where: { name } });
+
+        if (existingGenre) {
+            return existingGenre;
+        }
+
+        return models.genre.create({ data: { name } });
+    }));
+};
+
+const syncAlbumCover = async ({
+    album,
+    pictureData,
+    cachePath,
+    resizedPath
+}: {
+    album: Album;
+    pictureData: Buffer | null;
+    cachePath: string;
+    resizedPath: string;
+}) => {
+    if (!pictureData) {
+        return album.cover;
+    }
+
+    const fileName = `${album.id}.jpg`;
+    const savePath = path.join(cachePath, fileName);
+
+    const hasCache = fs.existsSync(savePath);
+    const shouldUpdate = hasCache && (
+        fs.readFileSync(savePath).toString() !== pictureData.toString()
+    );
+
+    if (!hasCache || shouldUpdate) {
+        fs.writeFileSync(savePath, pictureData);
+    }
+
+    const resizedSavePath = path.join(resizedPath, fileName);
+    if (!fs.existsSync(resizedSavePath) || shouldUpdate) {
+        await sharp(savePath)
+            .resize(300, 300)
+            .toFile(resizedSavePath);
+    }
+
+    const coverPath = `/cache/resized/${fileName}`;
+    if (album.cover !== coverPath) {
+        await models.album.update({
+            where: { id: album.id },
+            data: { cover: coverPath }
+        });
+    }
+
+    return coverPath;
+};
+
+const upsertMusicFromMetadata = async ({
+    existingMusic,
+    filePath,
+    contentHash,
+    metadata,
+    observedAt,
+    syncStatus,
+    cachePath,
+    resizedPath
+}: {
+    existingMusic?: Music;
+    filePath: string;
+    contentHash: string;
+    metadata: ParsedTrackMetadata;
+    observedAt: Date;
+    syncStatus: TrackSyncStatus;
+    cachePath: string;
+    resizedPath: string;
+}) => {
+    const artist = await findOrCreateArtist(metadata.artist);
+    const albumArtist = metadata.albumArtist
+        ? await findOrCreateArtist(metadata.albumArtist)
+        : null;
+    const album = await findOrCreateAlbum({
+        name: metadata.album,
+        publishedYear: metadata.year,
+        artistId: albumArtist ? albumArtist.id : artist.id
+    });
+    const genres = await findOrCreateGenres(metadata.genres);
+
+    await syncAlbumCover({
+        album,
+        pictureData: metadata.pictureData,
+        cachePath,
+        resizedPath
+    });
+
+    if (existingMusic) {
+        return models.music.update({
+            where: { id: existingMusic.id },
+            data: {
+                codec: metadata.codec,
+                container: metadata.container,
+                bitrate: metadata.bitrate,
+                sampleRate: metadata.sampleRate,
+                name: metadata.title,
+                duration: metadata.duration,
+                trackNumber: metadata.trackNumber,
+                filePath,
+                contentHash,
+                hashVersion: TRACK_CONTENT_HASH_VERSION,
+                lastSeenAt: observedAt,
+                missingSinceAt: null,
+                syncStatus,
+                albumId: album.id,
+                artistId: artist.id,
+                Genre: { set: genres.map((genre) => ({ id: genre.id })) }
+            }
+        });
+    }
+
+    return models.music.create({
+        data: {
+            codec: metadata.codec,
+            container: metadata.container,
+            bitrate: metadata.bitrate,
+            sampleRate: metadata.sampleRate,
+            name: metadata.title,
+            duration: metadata.duration,
+            trackNumber: metadata.trackNumber,
+            filePath,
+            contentHash,
+            hashVersion: TRACK_CONTENT_HASH_VERSION,
+            lastSeenAt: observedAt,
+            missingSinceAt: null,
+            syncStatus,
+            Album: { connect: { id: album.id } },
+            Artist: { connect: { id: artist.id } },
+            Genre: { connect: genres.map((genre) => ({ id: genre.id })) }
+        }
+    });
+};
+
+const updateMusicIdentity = async ({
+    music,
+    contentHash
+}: {
+    music: Music;
+    contentHash: string;
+}) => {
+    return models.music.update({
+        where: { id: music.id },
+        data: {
+            contentHash,
+            hashVersion: TRACK_CONTENT_HASH_VERSION
+        }
+    });
+};
+
+const pruneEmptyLibraryNodes = async () => {
+    const existingAlbums = await models.album.findMany({ include: { Music: true } });
+
+    for (const album of existingAlbums) {
+        if (album.Music.length === 0) {
+            await models.album.delete({ where: { id: album.id } });
+        }
+    }
+
+    const existingArtists = await models.artist.findMany({
+        include: {
+            Album: {},
+            Music: {}
+        }
+    });
+
+    for (const artist of existingArtists) {
+        if (artist.Album.length === 0 && artist.Music.length === 0) {
+            await models.artist.delete({ where: { id: artist.id } });
+        }
+    }
+};
 
 export const syncListener = (socket: Socket) => {
     let alreadySyncing = false;
 
-    socket.on('sync-music', async ({ force = false }) => {
-        console.log('sync-music');
-        socket.emit('sync-music', 'syncing...');
+    socket.on(SYNC_EVENT, async ({ force = false }) => {
+        console.log(SYNC_EVENT);
+        emitSyncMessage(socket, 'syncing...');
 
         if (alreadySyncing) {
             console.error('already syncing');
-            socket.emit('sync-music', 'error');
+            emitSyncMessage(socket, 'error');
             return;
         }
 
@@ -30,224 +363,208 @@ export const syncListener = (socket: Socket) => {
     });
 };
 
-export const syncMusic = async (socket: Socket, force = false) => {
+export const syncMusic = async (socket: Pick<Socket, 'emit'>, force = false): Promise<SyncMusicResult | null> => {
     try {
         const files = (await walk(path.resolve('./music')))
-            .filter((file) =>
-                file.endsWith('.mp3') ||
-                file.endsWith('.aac') ||
-                file.endsWith('.wav') ||
-                file.endsWith('.ogg') ||
-                file.endsWith('.flac'));
+            .filter(isSupportedAudioFile)
+            .sort();
+        const visiblePaths = new Set(files);
+        const observedAt = new Date();
+
         console.log(`find ${files.length} files`);
-        socket.emit('sync-music', `find ${files.length} files`);
-
-        let $existMusics = await models.music.findMany();
-
-        const filteredFiles = force ? files : files.filter((file) => {
-            for (const existMusic of $existMusics) {
-                if (existMusic.filePath === file) {
-                    return false;
-                }
-            }
-            return true;
-        });
-
-        console.log(`indexing ${filteredFiles.length} files`);
-        socket.emit('sync-music', `indexing ${filteredFiles.length} files`);
+        emitSyncMessage(socket, `find ${files.length} files`);
 
         const cachePath = path.resolve('./cache');
-        if (!fs.existsSync(cachePath)) {
-            fs.mkdirSync(cachePath);
-        }
         const resizedPath = path.join(cachePath, 'resized');
-        if (!fs.existsSync(resizedPath)) {
-            fs.mkdirSync(resizedPath);
-        }
+        ensureDirectory(cachePath);
+        ensureDirectory(resizedPath);
 
-        for (const file of filteredFiles) {
-            console.log(`sync... ${file}`);
-            socket.emit('sync-music', `sync... ${filteredFiles.indexOf(file) + 1}/${filteredFiles.length}`);
+        const musics = await models.music.findMany({ orderBy: { id: 'asc' } });
+        const musicById = new Map(musics.map((music) => [music.id, music]));
+        const musicByPath = new Map(musics.map((music) => [music.filePath, music]));
+        const identityRecordById = new Map(musics.map((music) => [music.id, toTrackIdentityRecord(music)]));
+        const indexedFiles = files.filter((filePath) => {
+            const music = musicByPath.get(filePath);
 
-            const data = fs.readFileSync(path.resolve('./music', file));
-
-            const { format, common } = await parseBuffer(data);
-            const {
-                container = '',
-                codec = '',
-                bitrate = 0,
-                duration = 0,
-                sampleRate = 0
-            } = format;
-            const {
-                title = file.split('/').pop().split('.').shift(),
-                albumartist: albumArtist = null,
-                artist = 'unknown',
-                album = 'unknown',
-                picture,
-                genre,
-                year = (new Date()).getFullYear(),
-                track
-            } = common;
-
-            let $artist = await models.artist.findFirst({ where: { name: artist } });
-
-            if (!$artist) {
-                $artist = await models.artist.create({ data: { name: artist } });
+            if (!music) {
+                return true;
             }
 
-            let $albumArtist = null;
+            return force || shouldRefreshTrackContentHash({
+                contentHash: music.contentHash,
+                hashVersion: music.hashVersion
+            });
+        }).length;
+        const result: SyncMusicResult = {
+            scannedFiles: files.length,
+            indexedFiles,
+            created: [],
+            moved: [],
+            duplicate: [],
+            missing: []
+        };
+        const orderedFiles = [
+            ...files.filter((filePath) => musicByPath.has(filePath)),
+            ...files.filter((filePath) => !musicByPath.has(filePath))
+        ];
 
-            if (albumArtist) {
-                $albumArtist = await models.artist.findFirst({ where: { name: albumArtist } });
+        console.log(`indexing ${indexedFiles} files`);
+        emitSyncMessage(socket, `indexing ${indexedFiles} files`);
 
-                if (!$albumArtist) {
-                    $albumArtist = await models.artist.create({ data: { name: albumArtist } });
-                }
+        const upsertKnownMusic = (music: Music) => {
+            const previousMusic = musicById.get(music.id);
+
+            if (previousMusic) {
+                musicByPath.delete(previousMusic.filePath);
             }
 
-            let $album = await models.album.findFirst({
-                where: {
-                    name: album,
-                    Artist: { name: albumArtist || artist }
-                }
+            musicById.set(music.id, music);
+            musicByPath.set(music.filePath, music);
+            identityRecordById.set(music.id, toTrackIdentityRecord(music));
+        };
+
+        for (const [index, filePath] of orderedFiles.entries()) {
+            console.log(`sync... ${filePath}`);
+            emitSyncMessage(socket, `sync... ${index + 1}/${files.length}`);
+
+            const pathMatch = musicByPath.get(filePath);
+            const requiresHashRefresh = !pathMatch || force || shouldRefreshTrackContentHash({
+                contentHash: pathMatch.contentHash,
+                hashVersion: pathMatch.hashVersion
             });
 
-            if (!$album) {
-                $album = await models.album.create({
-                    data: {
-                        name: album,
-                        cover: '',
-                        publishedYear: year.toString(),
-                        Artist: { connect: { id: albumArtist ? $albumArtist.id : $artist.id } }
-                    }
+            let fileData: Buffer | null = null;
+            let contentHash = pathMatch?.contentHash ?? null;
+
+            if (requiresHashRefresh) {
+                fileData = fs.readFileSync(filePath);
+                contentHash = createTrackContentHash(fileData);
+            }
+
+            if (pathMatch) {
+                if (force) {
+                    const metadata = await parseTrackMetadata(filePath, fileData ?? fs.readFileSync(filePath));
+                    const updatedMusic = await upsertMusicFromMetadata({
+                        existingMusic: pathMatch,
+                        filePath,
+                        contentHash: contentHash ?? createTrackContentHash(fs.readFileSync(filePath)),
+                        metadata,
+                        observedAt,
+                        syncStatus: pathMatch.syncStatus as TrackSyncStatus,
+                        cachePath,
+                        resizedPath
+                    });
+                    upsertKnownMusic(updatedMusic);
+                    continue;
+                }
+
+                if (requiresHashRefresh && contentHash) {
+                    const updatedMusic = await updateMusicIdentity({
+                        music: pathMatch,
+                        contentHash
+                    });
+                    upsertKnownMusic(updatedMusic);
+                }
+
+                continue;
+            }
+
+            const resolvedFileData = fileData ?? fs.readFileSync(filePath);
+            const resolvedContentHash = contentHash ?? createTrackContentHash(resolvedFileData);
+            const metadata = await parseTrackMetadata(filePath, resolvedFileData);
+            const match = classifyTrackIdentityCandidate(
+                [...identityRecordById.values()],
+                {
+                    filePath,
+                    contentHash: resolvedContentHash
+                },
+                visiblePaths
+            );
+
+            if (match.kind === 'moved') {
+                const existingMusic = musicById.get(match.record.id);
+
+                if (!existingMusic) {
+                    continue;
+                }
+
+                const movedMusic = await upsertMusicFromMetadata({
+                    existingMusic,
+                    filePath,
+                    contentHash: resolvedContentHash,
+                    metadata,
+                    observedAt,
+                    syncStatus: TRACK_SYNC_STATUS.active,
+                    cachePath,
+                    resizedPath
                 });
-            }
-
-            let coverPath = '';
-            if (picture?.[0]?.data) {
-                const fileName = $album.id + '.jpg';
-                const savePath = path.join(cachePath, fileName);
-
-                const hasCache = fs.existsSync(savePath);
-                const shouldUpdate = hasCache && (
-                    fs.readFileSync(savePath).toString() !== picture[0].data.toString()
-                );
-                if (!hasCache || shouldUpdate) {
-                    fs.writeFileSync(savePath, picture[0].data);
-                }
-
-                const resizedFileName = $album.id + '.jpg';
-                const resizedSavePath = path.join(resizedPath, resizedFileName);
-                if (!fs.existsSync(resizedSavePath) || shouldUpdate) {
-                    await sharp(savePath)
-                        .resize(300, 300)
-                        .toFile(resizedSavePath);
-                }
-                coverPath = '/cache/resized/' + fileName;
-            }
-
-            if (coverPath && $album.cover !== coverPath) {
-                $album = await models.album.update({
-                    where: { id: $album.id },
-                    data: { cover: coverPath }
+                upsertKnownMusic(movedMusic);
+                result.moved.push({
+                    musicId: movedMusic.id,
+                    filePath
                 });
+                continue;
             }
 
-            const promises = genre?.map(async (name) => {
-                const $genre = await models.genre.findUnique({ where: { name } });
-
-                if (!$genre) {
-                    return await models.genre.create({ data: { name } });
-                }
-
-                return $genre;
+            const createdMusic = await upsertMusicFromMetadata({
+                filePath,
+                contentHash: resolvedContentHash,
+                metadata,
+                observedAt,
+                syncStatus: match.kind === 'duplicate'
+                    ? TRACK_SYNC_STATUS.duplicate
+                    : TRACK_SYNC_STATUS.active,
+                cachePath,
+                resizedPath
             });
+            upsertKnownMusic(createdMusic);
 
-            const $genres = promises ? await Promise.all(promises) : [];
+            if (match.kind === 'duplicate') {
+                result.duplicate.push({
+                    musicId: createdMusic.id,
+                    filePath
+                });
+            } else {
+                result.created.push({
+                    musicId: createdMusic.id,
+                    filePath
+                });
+            }
+        }
 
-            const $music = await models.music.findFirst({
-                where: {
-                    codec,
-                    container,
-                    bitrate,
-                    sampleRate,
-                    name: title,
-                    duration,
-                    trackNumber: track?.no || 1,
-                    filePath: file,
-                    albumId: $album.id,
-                    artistId: $artist.id
+        const presenceUpdates = deriveTrackPresenceUpdates(
+            [...identityRecordById.values()],
+            visiblePaths,
+            observedAt
+        );
+
+        for (const presenceUpdate of presenceUpdates) {
+            const updatedMusic = await models.music.update({
+                where: { id: presenceUpdate.id },
+                data: {
+                    lastSeenAt: presenceUpdate.lastSeenAt,
+                    missingSinceAt: presenceUpdate.missingSinceAt,
+                    syncStatus: presenceUpdate.syncStatus
                 }
             });
+            upsertKnownMusic(updatedMusic);
 
-            if (!$music) {
-                await models.music.create({
-                    data: {
-                        codec,
-                        container,
-                        bitrate,
-                        sampleRate,
-                        name: title,
-                        duration,
-                        trackNumber: track?.no || 1,
-                        filePath: file,
-                        Album: { connect: { id: $album.id } },
-                        Artist: { connect: { id: $artist.id } },
-                        Genre: { connect: $genres.map((genre) => ({ id: genre.id })) }
-                    }
-                });
-            } else if ($music.filePath !== file) {
-                await models.music.update({
-                    where: { id: $music.id },
-                    data: { filePath: file }
+            if (presenceUpdate.syncStatus === TRACK_SYNC_STATUS.missing) {
+                result.missing.push({
+                    musicId: updatedMusic.id,
+                    filePath: updatedMusic.filePath
                 });
             }
         }
 
-        $existMusics = await models.music.findMany();
+        await pruneEmptyLibraryNodes();
+        console.log('sync-music done');
+        emitSyncMessage(socket, 'done');
 
-        for (const music of $existMusics) {
-            if (!files.includes(music.filePath)) {
-                console.log(`delete music from db... ${music.name}`);
-                socket.emit('sync-music', `delete music from db... ${music.name}`);
-                await models.playlistMusic.deleteMany({ where: { musicId: music.id } });
-                await models.musicHate.deleteMany({ where: { musicId: music.id } });
-                await models.musicLike.deleteMany({ where: { musicId: music.id } });
-                await models.music.delete({ where: { id: music.id } });
-            }
-        }
-
-        const $existAlbums = await models.album.findMany({ include: { Music: true } });
-
-        for (const album of $existAlbums) {
-            if (album.Music.length === 0) {
-                console.log(`delete album from db... ${album.name}`);
-                socket.emit('sync-music', `delete album from db... ${album.name}`);
-                await models.album.delete({ where: { id: album.id } });
-            }
-        }
-
-        const $existArtists = await models.artist.findMany({
-            include: {
-                Album: {},
-                Music: {}
-            }
-        });
-
-        for (const artist of $existArtists) {
-            if (artist.Album.length === 0 && artist.Music.length === 0) {
-                console.log(`delete artist from db... ${artist.name}`);
-                socket.emit('sync-music', `delete artist from db... ${artist.name}`);
-                await models.artist.delete({ where: { id: artist.id } });
-            }
-        }
+        return result;
     } catch (error) {
         console.error(error);
-        socket.emit('sync-music', 'error');
-        return;
+        emitSyncMessage(socket, 'error');
+        return null;
     }
-
-    console.log('sync-music done');
-    socket.emit('sync-music', 'done');
 };


### PR DESCRIPTION
## :dart: Goal
Add track identity handling to sync so file moves preserve continuity, duplicates are separated from real moves, and missing files are retained without destructive deletion.

## :hammer_and_wrench: Core Changes
- Add track identity foundation fields and migration on `Music` for content hash, hash version, last seen, missing since, and sync status.
- Wire `sync.ts` to process path matches first, compute hashes for unresolved paths, and classify each scan result as `created`, `moved`, `duplicate`, or `missing`.
- Keep moved tracks on the same `Music` row so likes, playlist links, and playback history stay attached.
- Add `track-hash.ts` and extend track identity rules so visible hash collisions resolve to one `active` row and later copies stay `duplicate`.
- Filter normal library GraphQL queries to `active` tracks so `missing` and `duplicate` rows stay internal until a later sync report UI.
- Add integration coverage for move, duplicate, and missing sync scenarios.

## :brain: Key Decisions
- Use content hash as the first identity layer instead of path-only matching because path changes are not stable enough for personal libraries.
- Mark missing tracks instead of deleting them immediately so temporary mount or storage failures do not destroy continuity.
- Hide `missing` and `duplicate` rows from current library surfaces to avoid regressing the existing listening UX before Feature E exposes sync reporting.
- Process known paths before new paths during sync so an existing visible original is established before duplicate classification runs.

## :test_tube: Verification Guide
- `cd server/src && pnpm test`
  - Expected: all Jest suites pass, including `src/socket/sync.test.ts` move/duplicate/missing coverage.
- `cd server/src && pnpm build`
  - Expected: TypeScript build passes with no errors.
- `cd server/src && pnpm lint`
  - Expected: ESLint exits successfully. Existing `no-console` warnings remain in older server files, but there are no lint errors in this PR scope.
- Manual check: move a liked or playlisted music file and run sync.
  - Expected: the same track identity remains, with likes/playlist links/play counts preserved.
- Manual check: duplicate a file and run sync.
  - Expected: the duplicate does not appear as a separate normal library track.
- Manual check: remove a file and run sync.
  - Expected: the track disappears from normal library views but is retained internally as `missing`.

## :white_check_mark: Checklist
- [x] Local validation for changed scope completed
- [x] PR title follows `<emoji> <subject>`
- [x] No unrelated user changes were included
- [x] Schema and migration changes are included in this branch
- [x] Ready for review