### PR TITLE
✨ Add sync report summary

### DIFF
--- a/server/src/client/src/api/index.ts
+++ b/server/src/client/src/api/index.ts
@@ -1,5 +1,12 @@
 import axios from 'axios';
-import type { Artist, Album, Music, Playlist } from '~/models/type';
+import type {
+    Artist,
+    Album,
+    Music,
+    Playlist,
+    SyncReport,
+    SyncReportItem
+} from '~/models/type';
 
 export type AuthMode = 'open' | 'password-protected';
 
@@ -203,4 +210,59 @@ export function getAudio(id: string) {
         url: `/api/audio/${id}`,
         responseType: 'blob'
     });
+}
+
+export function getLatestSyncReport() {
+    return graphQLRequest<'latestSyncReport', SyncReport | null>(
+        wrapper('query', createQuery<SyncReport>('latestSyncReport', [
+            'id',
+            'createdAt',
+            'startedAt',
+            'completedAt',
+            'status',
+            'force',
+            'scannedFiles',
+            'indexedFiles',
+            'createdCount',
+            'movedCount',
+            'duplicateCount',
+            'missingCount',
+            createQuery<SyncReportItem>('created', [
+                'id',
+                'kind',
+                'musicId',
+                'musicName',
+                'filePath',
+                'previousFilePath',
+                'createdAt'
+            ]),
+            createQuery<SyncReportItem>('moved', [
+                'id',
+                'kind',
+                'musicId',
+                'musicName',
+                'filePath',
+                'previousFilePath',
+                'createdAt'
+            ]),
+            createQuery<SyncReportItem>('duplicate', [
+                'id',
+                'kind',
+                'musicId',
+                'musicName',
+                'filePath',
+                'previousFilePath',
+                'createdAt'
+            ]),
+            createQuery<SyncReportItem>('missing', [
+                'id',
+                'kind',
+                'musicId',
+                'musicName',
+                'filePath',
+                'previousFilePath',
+                'createdAt'
+            ])
+        ]))
+    );
 }

--- a/server/src/client/src/models/type.ts
+++ b/server/src/client/src/models/type.ts
@@ -53,3 +53,32 @@ export interface Playlist {
     createdAt: string;
     updatedAt: string;
 }
+
+export interface SyncReportItem {
+    id: string;
+    kind: 'created' | 'moved' | 'duplicate' | 'missing';
+    musicId: string | null;
+    musicName: string;
+    filePath: string;
+    previousFilePath: string | null;
+    createdAt: string;
+}
+
+export interface SyncReport {
+    id: string;
+    createdAt: string;
+    startedAt: string;
+    completedAt: string | null;
+    status: 'success' | 'error';
+    force: boolean;
+    scannedFiles: number;
+    indexedFiles: number;
+    createdCount: number;
+    movedCount: number;
+    duplicateCount: number;
+    missingCount: number;
+    created: SyncReportItem[];
+    moved: SyncReportItem[];
+    duplicate: SyncReportItem[];
+    missing: SyncReportItem[];
+}

--- a/server/src/client/src/pages/Setting/components/SynchronizationSection/SynchronizationSection.module.scss
+++ b/server/src/client/src/pages/Setting/components/SynchronizationSection/SynchronizationSection.module.scss
@@ -4,6 +4,125 @@
   margin-top: 16px;
 }
 
+.reportCard {
+  margin-top: 20px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid var(--b-color-border, rgba(255, 255, 255, 0.08));
+  background: rgba(var(--b-color-hover-rgb), 0.04);
+}
+
+.reportHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+
+  &.success {
+    background: rgba(56, 189, 120, 0.14);
+    color: #38bd78;
+  }
+
+  &.error {
+    background: rgba(244, 63, 94, 0.14);
+    color: #f43f5e;
+  }
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.summaryItem {
+  padding: 12px;
+  border-radius: 12px;
+  background: rgba(var(--b-color-hover-rgb), 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.summaryLabel {
+  font-size: 0.75rem;
+  opacity: 0.75;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.reportMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.reportDetails {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.detailGroup {
+  border-radius: 12px;
+  background: rgba(var(--b-color-hover-rgb), 0.06);
+  overflow: hidden;
+
+  summary {
+    list-style: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 14px;
+    cursor: pointer;
+    font-weight: 600;
+  }
+
+  summary::-webkit-details-marker {
+    display: none;
+  }
+}
+
+.detailList {
+  list-style: none;
+  margin: 0;
+  padding: 0 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.detailItem {
+  padding-top: 10px;
+  border-top: 1px solid rgba(var(--b-color-hover-rgb), 0.12);
+
+  &:first-child {
+    border-top: 0;
+    padding-top: 0;
+  }
+}
+
+.emptyDetail {
+  margin: 0;
+  padding: 0 14px 14px;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
 .progressContainer {
   margin: 16px 0;
   width: 100%;
@@ -41,5 +160,15 @@
   }
   100% {
     transform: translateX(300%);
+  }
+}
+
+@media (max-width: 720px) {
+  .summaryGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .reportHeader {
+    flex-direction: column;
   }
 }

--- a/server/src/client/src/pages/Setting/components/SynchronizationSection/SynchronizationSection.tsx
+++ b/server/src/client/src/pages/Setting/components/SynchronizationSection/SynchronizationSection.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from 'react-query';
 
-import { Button, SettingSection, SettingItem } from '~/components/shared';
+import { Button, SettingSection, SettingItem, Text } from '~/components/shared';
+import { getLatestSyncReport } from '~/api';
 import { toast } from '~/modules/toast';
 import { socket } from '~/socket';
+import type { SyncReport, SyncReportItem } from '~/models/type';
 
 import styles from './SynchronizationSection.module.scss';
 
@@ -23,9 +26,64 @@ const SyncIcon = () => (
     </svg>
 );
 
+const formatTimestamp = (value: string | null) => {
+    if (!value) {
+        return 'Unavailable';
+    }
+
+    return new Date(value).toLocaleString();
+};
+
+const buildDetailLabel = (item: SyncReportItem) => {
+    if (item.kind === 'moved' && item.previousFilePath) {
+        return `${item.previousFilePath} -> ${item.filePath}`;
+    }
+
+    return item.filePath;
+};
+
+const reportSections = (report: SyncReport | null) => {
+    if (!report) {
+        return [];
+    }
+
+    return [
+        {
+            key: 'created',
+            title: 'Created',
+            count: report.createdCount,
+            items: report.created
+        },
+        {
+            key: 'moved',
+            title: 'Moved',
+            count: report.movedCount,
+            items: report.moved
+        },
+        {
+            key: 'duplicate',
+            title: 'Duplicate',
+            count: report.duplicateCount,
+            items: report.duplicate
+        },
+        {
+            key: 'missing',
+            title: 'Missing',
+            count: report.missingCount,
+            items: report.missing
+        }
+    ];
+};
+
 export const SynchronizationSection = ({ onSyncMusic }: SynchronizationSectionProps) => {
     const [progressMessage, setProgressMessage] = useState('');
     const [isSyncing, setIsSyncing] = useState(false);
+    const queryClient = useQueryClient();
+    const { data: latestSyncReport } = useQuery(
+        ['sync-report'],
+        () => getLatestSyncReport().then((response) => response.data.latestSyncReport)
+    );
+    const sections = useMemo(() => reportSections(latestSyncReport ?? null), [latestSyncReport]);
 
     useEffect(() => {
         socket.on('sync-music', (serverMessage: string | 'done' | 'error') => {
@@ -37,6 +95,7 @@ export const SynchronizationSection = ({ onSyncMusic }: SynchronizationSectionPr
                 }
 
                 setIsSyncing(false);
+                queryClient.invalidateQueries(['sync-report']);
                 setTimeout(() => {
                     setProgressMessage('');
                 }, 1000);
@@ -49,7 +108,7 @@ export const SynchronizationSection = ({ onSyncMusic }: SynchronizationSectionPr
         return () => {
             socket.off('sync-music');
         };
-    }, []);
+    }, [queryClient]);
 
     const handleSync = async (force: boolean) => {
         setIsSyncing(true);
@@ -88,6 +147,87 @@ export const SynchronizationSection = ({ onSyncMusic }: SynchronizationSectionPr
                             Force Sync
                         </Button>
                     </div>
+
+                    {latestSyncReport && (
+                        <div className={styles.reportCard}>
+                            <div className={styles.reportHeader}>
+                                <div>
+                                    <Text as="h5" size="md" weight="semibold">
+                                        Latest Sync Report
+                                    </Text>
+                                    <Text as="p" variant="tertiary" size="sm">
+                                        Started {formatTimestamp(latestSyncReport.startedAt)}
+                                    </Text>
+                                </div>
+                                <span className={`${styles.statusBadge} ${styles[latestSyncReport.status]}`}>
+                                    {latestSyncReport.status}
+                                </span>
+                            </div>
+
+                            <div className={styles.summaryGrid}>
+                                <div className={styles.summaryItem}>
+                                    <span className={styles.summaryLabel}>Scanned</span>
+                                    <strong>{latestSyncReport.scannedFiles}</strong>
+                                </div>
+                                <div className={styles.summaryItem}>
+                                    <span className={styles.summaryLabel}>Indexed</span>
+                                    <strong>{latestSyncReport.indexedFiles}</strong>
+                                </div>
+                                <div className={styles.summaryItem}>
+                                    <span className={styles.summaryLabel}>Created</span>
+                                    <strong>{latestSyncReport.createdCount}</strong>
+                                </div>
+                                <div className={styles.summaryItem}>
+                                    <span className={styles.summaryLabel}>Moved</span>
+                                    <strong>{latestSyncReport.movedCount}</strong>
+                                </div>
+                                <div className={styles.summaryItem}>
+                                    <span className={styles.summaryLabel}>Duplicate</span>
+                                    <strong>{latestSyncReport.duplicateCount}</strong>
+                                </div>
+                                <div className={styles.summaryItem}>
+                                    <span className={styles.summaryLabel}>Missing</span>
+                                    <strong>{latestSyncReport.missingCount}</strong>
+                                </div>
+                            </div>
+
+                            <div className={styles.reportMeta}>
+                                <Text as="p" variant="tertiary" size="sm">
+                                    Completed {formatTimestamp(latestSyncReport.completedAt)}
+                                </Text>
+                                <Text as="p" variant="tertiary" size="sm">
+                                    Mode: {latestSyncReport.force ? 'Force sync' : 'Normal sync'}
+                                </Text>
+                            </div>
+
+                            <div className={styles.reportDetails}>
+                                {sections.map((section) => (
+                                    <details key={section.key} className={styles.detailGroup}>
+                                        <summary>
+                                            <span>{section.title}</span>
+                                            <span>{section.count}</span>
+                                        </summary>
+                                        {section.items.length === 0 ? (
+                                            <p className={styles.emptyDetail}>No items in this group.</p>
+                                        ) : (
+                                            <ul className={styles.detailList}>
+                                                {section.items.map((item) => (
+                                                    <li key={item.id} className={styles.detailItem}>
+                                                        <Text as="p" size="sm" weight="semibold">
+                                                            {item.musicName}
+                                                        </Text>
+                                                        <Text as="p" variant="tertiary" size="sm">
+                                                            {buildDetailLabel(item)}
+                                                        </Text>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        )}
+                                    </details>
+                                ))}
+                            </div>
+                        </div>
+                    )}
                 </div>
             </SettingItem>
         </SettingSection>

--- a/server/src/prisma/migrations/20260410003000_0005_sync_report_foundation/migration.sql
+++ b/server/src/prisma/migrations/20260410003000_0005_sync_report_foundation/migration.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "SyncReport" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "startedAt" DATETIME NOT NULL,
+    "completedAt" DATETIME,
+    "status" TEXT NOT NULL,
+    "force" BOOLEAN NOT NULL DEFAULT false,
+    "scannedFiles" INTEGER NOT NULL DEFAULT 0,
+    "indexedFiles" INTEGER NOT NULL DEFAULT 0,
+    "createdCount" INTEGER NOT NULL DEFAULT 0,
+    "movedCount" INTEGER NOT NULL DEFAULT 0,
+    "duplicateCount" INTEGER NOT NULL DEFAULT 0,
+    "missingCount" INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE "SyncReportItem" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "kind" TEXT NOT NULL,
+    "musicId" INTEGER,
+    "musicName" TEXT NOT NULL,
+    "filePath" TEXT NOT NULL,
+    "previousFilePath" TEXT,
+    "syncReportId" INTEGER NOT NULL,
+    CONSTRAINT "SyncReportItem_syncReportId_fkey" FOREIGN KEY ("syncReportId") REFERENCES "SyncReport" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE INDEX "SyncReport_createdAt_idx" ON "SyncReport"("createdAt");
+CREATE INDEX "SyncReport_status_createdAt_idx" ON "SyncReport"("status", "createdAt");
+CREATE INDEX "SyncReportItem_syncReportId_kind_idx" ON "SyncReportItem"("syncReportId", "kind");

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -73,6 +73,40 @@ model Music {
     @@index([syncStatus, missingSinceAt])
 }
 
+model SyncReport {
+    id             Int              @id @default(autoincrement())
+    createdAt      DateTime         @default(now())
+    updatedAt      DateTime         @updatedAt
+    startedAt      DateTime
+    completedAt    DateTime?
+    status         String
+    force          Boolean          @default(false)
+    scannedFiles   Int              @default(0)
+    indexedFiles   Int              @default(0)
+    createdCount   Int              @default(0)
+    movedCount     Int              @default(0)
+    duplicateCount Int              @default(0)
+    missingCount   Int              @default(0)
+    Item           SyncReportItem[]
+
+    @@index([createdAt])
+    @@index([status, createdAt])
+}
+
+model SyncReportItem {
+    id               Int        @id @default(autoincrement())
+    createdAt        DateTime   @default(now())
+    kind             String
+    musicId          Int?
+    musicName        String
+    filePath         String
+    previousFilePath String?
+    SyncReport       SyncReport @relation(fields: [syncReportId], references: [id], onDelete: Cascade)
+    syncReportId     Int
+
+    @@index([syncReportId, kind])
+}
+
 model PlaybackEvent {
     id             Int      @id @default(autoincrement())
     createdAt      DateTime @default(now())

--- a/server/src/src/modules/sync-report.ts
+++ b/server/src/src/modules/sync-report.ts
@@ -1,0 +1,15 @@
+export const SYNC_REPORT_STATUS = {
+    success: 'success',
+    error: 'error'
+} as const;
+
+export type SyncReportStatus = typeof SYNC_REPORT_STATUS[keyof typeof SYNC_REPORT_STATUS];
+
+export const SYNC_REPORT_KIND = {
+    created: 'created',
+    moved: 'moved',
+    duplicate: 'duplicate',
+    missing: 'missing'
+} as const;
+
+export type SyncReportKind = typeof SYNC_REPORT_KIND[keyof typeof SYNC_REPORT_KIND];

--- a/server/src/src/schema/index.ts
+++ b/server/src/src/schema/index.ts
@@ -2,20 +2,23 @@ import { makeExecutableSchema } from '@graphql-tools/schema';
 import { albumResolvers, albumTypeDefs } from './album';
 import { artistResolvers, artistTypeDefs } from './artist';
 import { musicResolvers, musicTypeDefs } from './music';
-import { playlistResolvers, playlistTypeDefs } from './playlist'; './playlist';
+import { playlistResolvers, playlistTypeDefs } from './playlist';
+import { syncReportResolvers, syncReportTypeDefs } from './sync-report';
 
 const schema = makeExecutableSchema({
     typeDefs: [
         albumTypeDefs,
         artistTypeDefs,
         musicTypeDefs,
-        playlistTypeDefs
+        playlistTypeDefs,
+        syncReportTypeDefs
     ],
     resolvers: [
         albumResolvers,
         artistResolvers,
         musicResolvers,
-        playlistResolvers
+        playlistResolvers,
+        syncReportResolvers
     ]
 });
 

--- a/server/src/src/schema/sync-report/index.ts
+++ b/server/src/src/schema/sync-report/index.ts
@@ -1,0 +1,75 @@
+import type { IResolvers } from '@graphql-tools/utils';
+
+import models from '~/models';
+import { gql } from '~/modules/graphql';
+import { SYNC_REPORT_KIND } from '~/modules/sync-report';
+
+export const syncReportType = gql`
+    type SyncReportItem {
+        id: ID!
+        kind: String!
+        musicId: ID
+        musicName: String!
+        filePath: String!
+        previousFilePath: String
+        createdAt: String!
+    }
+
+    type SyncReport {
+        id: ID!
+        createdAt: String!
+        startedAt: String!
+        completedAt: String
+        status: String!
+        force: Boolean!
+        scannedFiles: Int!
+        indexedFiles: Int!
+        createdCount: Int!
+        movedCount: Int!
+        duplicateCount: Int!
+        missingCount: Int!
+        created: [SyncReportItem!]!
+        moved: [SyncReportItem!]!
+        duplicate: [SyncReportItem!]!
+        missing: [SyncReportItem!]!
+    }
+`;
+
+export const syncReportQuery = gql`
+    type Query {
+        latestSyncReport: SyncReport
+    }
+`;
+
+export const syncReportTypeDefs = `
+    ${syncReportType}
+    ${syncReportQuery}
+`;
+
+const filterItemsByKind = (
+    kind: string,
+    items: Array<{ kind: string }> = []
+) => items.filter((item) => item.kind === kind);
+
+export const syncReportResolvers: IResolvers = {
+    Query: {
+        latestSyncReport: () => models.syncReport.findFirst({
+            orderBy: { createdAt: 'desc' },
+            include: { Item: { orderBy: { id: 'asc' } } }
+        })
+    },
+    SyncReport: {
+        created: (report: { Item?: Array<{ kind: string }> }) => {
+            return filterItemsByKind(SYNC_REPORT_KIND.created, report.Item);
+        },
+        moved: (report: { Item?: Array<{ kind: string }> }) => {
+            return filterItemsByKind(SYNC_REPORT_KIND.moved, report.Item);
+        },
+        duplicate: (report: { Item?: Array<{ kind: string }> }) => {
+            return filterItemsByKind(SYNC_REPORT_KIND.duplicate, report.Item);
+        },
+        missing: (report: { Item?: Array<{ kind: string }> }) => {
+            return filterItemsByKind(SYNC_REPORT_KIND.missing, report.Item);
+        }
+    }
+};

--- a/server/src/src/socket/sync.test.ts
+++ b/server/src/src/socket/sync.test.ts
@@ -19,6 +19,7 @@ jest.mock('sharp', () => {
 
 import { walk } from '../modules/file';
 import { TRACK_CONTENT_HASH_VERSION, createTrackContentHash } from '../modules/track-hash';
+import { SYNC_REPORT_KIND, SYNC_REPORT_STATUS } from '../modules/sync-report';
 import { TRACK_SYNC_STATUS } from '../modules/track-identity';
 import { syncMusic } from './sync';
 
@@ -132,6 +133,8 @@ describe('sync music identity', () => {
         });
 
         await models.playbackEvent.deleteMany();
+        await models.syncReportItem.deleteMany();
+        await models.syncReport.deleteMany();
         await models.playlistMusic.deleteMany();
         await models.playlist.deleteMany();
         await models.musicLike.deleteMany();
@@ -185,6 +188,10 @@ describe('sync music identity', () => {
         const movedMusic = await models.music.findUniqueOrThrow({ where: { id: existingMusic.id } });
         const like = await models.musicLike.findFirst({ where: { musicId: existingMusic.id } });
         const playlistLink = await models.playlistMusic.findFirst({ where: { musicId: existingMusic.id } });
+        const report = await models.syncReport.findFirstOrThrow({
+            orderBy: { createdAt: 'desc' },
+            include: { Item: true }
+        });
 
         expect(result).toMatchObject({
             moved: [{
@@ -197,6 +204,22 @@ describe('sync music identity', () => {
         expect(movedMusic.missingSinceAt).toBeNull();
         expect(like).not.toBeNull();
         expect(playlistLink).not.toBeNull();
+        expect(report).toMatchObject({
+            status: SYNC_REPORT_STATUS.success,
+            movedCount: 1,
+            createdCount: 0,
+            duplicateCount: 0,
+            missingCount: 0
+        });
+        expect(report.Item).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                kind: SYNC_REPORT_KIND.moved,
+                musicId: existingMusic.id,
+                musicName: movedMusic.name,
+                filePath: movedPath,
+                previousFilePath: path.join(tempDirectory, 'library/old/track-a.mp3')
+            })
+        ]));
     });
 
     it('creates a duplicate row but keeps the normal library scoped to active tracks', async () => {
@@ -225,6 +248,10 @@ describe('sync music identity', () => {
         const result = await syncMusic({ emit: jest.fn() } as never);
         const musics = await models.music.findMany({ orderBy: { id: 'asc' } });
         const visibleMusics = await (musicResolvers.Query as { allMusics: () => Promise<{ id: number }[]> }).allMusics();
+        const report = await models.syncReport.findFirstOrThrow({
+            orderBy: { createdAt: 'desc' },
+            include: { Item: true }
+        });
 
         expect(result).toMatchObject({
             duplicate: [{
@@ -244,6 +271,20 @@ describe('sync music identity', () => {
             syncStatus: TRACK_SYNC_STATUS.duplicate
         });
         expect(visibleMusics.map((music) => music.id)).toEqual([originalMusic.id]);
+        expect(report).toMatchObject({
+            status: SYNC_REPORT_STATUS.success,
+            createdCount: 0,
+            movedCount: 0,
+            duplicateCount: 1,
+            missingCount: 0
+        });
+        expect(report.Item).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                kind: SYNC_REPORT_KIND.duplicate,
+                filePath: copyPath,
+                musicName: musics[1].name
+            })
+        ]));
     });
 
     it('marks unseen tracks as missing instead of deleting them', async () => {
@@ -266,6 +307,10 @@ describe('sync music identity', () => {
         const result = await syncMusic({ emit: jest.fn() } as never);
         const missingMusic = await models.music.findUniqueOrThrow({ where: { id: existingMusic.id } });
         const visibleMusics = await (musicResolvers.Query as { allMusics: () => Promise<{ id: number }[]> }).allMusics();
+        const report = await models.syncReport.findFirstOrThrow({
+            orderBy: { createdAt: 'desc' },
+            include: { Item: true }
+        });
 
         expect(result).toMatchObject({
             missing: [{
@@ -278,5 +323,17 @@ describe('sync music identity', () => {
         expect(await models.musicLike.count({ where: { musicId: existingMusic.id } })).toBe(1);
         expect(await models.playlistMusic.count({ where: { musicId: existingMusic.id } })).toBe(1);
         expect(visibleMusics).toHaveLength(0);
+        expect(report).toMatchObject({
+            status: SYNC_REPORT_STATUS.success,
+            missingCount: 1
+        });
+        expect(report.Item).toEqual(expect.arrayContaining([
+            expect.objectContaining({
+                kind: SYNC_REPORT_KIND.missing,
+                musicId: existingMusic.id,
+                filePath: existingMusic.filePath,
+                musicName: existingMusic.name
+            })
+        ]));
     });
 });

--- a/server/src/src/socket/sync.ts
+++ b/server/src/src/socket/sync.ts
@@ -19,6 +19,11 @@ import {
     type TrackIdentityRecord,
     type TrackSyncStatus
 } from '../modules/track-identity';
+import {
+    SYNC_REPORT_KIND,
+    SYNC_REPORT_STATUS,
+    type SyncReportStatus
+} from '../modules/sync-report';
 
 import models, { type Album, type Artist, type Genre, type Music } from '~/models';
 
@@ -50,7 +55,9 @@ interface ParsedTrackMetadata {
 
 interface SyncResultEntry {
     musicId: number;
+    musicName: string;
     filePath: string;
+    previousFilePath: string | null;
 }
 
 export interface SyncMusicResult {
@@ -343,6 +350,60 @@ const pruneEmptyLibraryNodes = async () => {
     }
 };
 
+const flattenSyncReportEntries = (result: SyncMusicResult) => {
+    return ([
+        [SYNC_REPORT_KIND.created, result.created],
+        [SYNC_REPORT_KIND.moved, result.moved],
+        [SYNC_REPORT_KIND.duplicate, result.duplicate],
+        [SYNC_REPORT_KIND.missing, result.missing]
+    ] as const).flatMap(([kind, entries]) => {
+        return entries.map((entry) => ({
+            kind,
+            ...entry
+        }));
+    });
+};
+
+const persistSyncReport = async ({
+    startedAt,
+    completedAt,
+    force,
+    status,
+    result
+}: {
+    startedAt: Date;
+    completedAt: Date;
+    force: boolean;
+    status: SyncReportStatus;
+    result: SyncMusicResult;
+}) => {
+    const items = flattenSyncReportEntries(result);
+
+    return models.syncReport.create({
+        data: {
+            startedAt,
+            completedAt,
+            force,
+            status,
+            scannedFiles: result.scannedFiles,
+            indexedFiles: result.indexedFiles,
+            createdCount: result.created.length,
+            movedCount: result.moved.length,
+            duplicateCount: result.duplicate.length,
+            missingCount: result.missing.length,
+            Item: {
+                create: items.map((entry) => ({
+                    kind: entry.kind,
+                    musicId: entry.musicId,
+                    musicName: entry.musicName,
+                    filePath: entry.filePath,
+                    previousFilePath: entry.previousFilePath
+                }))
+            }
+        }
+    });
+};
+
 export const syncListener = (socket: Socket) => {
     let alreadySyncing = false;
 
@@ -357,19 +418,23 @@ export const syncListener = (socket: Socket) => {
         }
 
         alreadySyncing = true;
-        await syncMusic(socket, force);
-        connectors.broadcast('resync', '');
+        const syncResult = await syncMusic(socket, force);
+        if (syncResult) {
+            connectors.broadcast('resync', '');
+        }
         alreadySyncing = false;
     });
 };
 
 export const syncMusic = async (socket: Pick<Socket, 'emit'>, force = false): Promise<SyncMusicResult | null> => {
+    const startedAt = new Date();
+
     try {
         const files = (await walk(path.resolve('./music')))
             .filter(isSupportedAudioFile)
             .sort();
         const visiblePaths = new Set(files);
-        const observedAt = new Date();
+        const observedAt = startedAt;
 
         console.log(`find ${files.length} files`);
         emitSyncMessage(socket, `find ${files.length} files`);
@@ -501,7 +566,9 @@ export const syncMusic = async (socket: Pick<Socket, 'emit'>, force = false): Pr
                 upsertKnownMusic(movedMusic);
                 result.moved.push({
                     musicId: movedMusic.id,
-                    filePath
+                    musicName: movedMusic.name,
+                    filePath,
+                    previousFilePath: match.record.filePath
                 });
                 continue;
             }
@@ -522,12 +589,16 @@ export const syncMusic = async (socket: Pick<Socket, 'emit'>, force = false): Pr
             if (match.kind === 'duplicate') {
                 result.duplicate.push({
                     musicId: createdMusic.id,
-                    filePath
+                    musicName: createdMusic.name,
+                    filePath,
+                    previousFilePath: null
                 });
             } else {
                 result.created.push({
                     musicId: createdMusic.id,
-                    filePath
+                    musicName: createdMusic.name,
+                    filePath,
+                    previousFilePath: null
                 });
             }
         }
@@ -552,18 +623,43 @@ export const syncMusic = async (socket: Pick<Socket, 'emit'>, force = false): Pr
             if (presenceUpdate.syncStatus === TRACK_SYNC_STATUS.missing) {
                 result.missing.push({
                     musicId: updatedMusic.id,
-                    filePath: updatedMusic.filePath
+                    musicName: updatedMusic.name,
+                    filePath: updatedMusic.filePath,
+                    previousFilePath: null
                 });
             }
         }
 
         await pruneEmptyLibraryNodes();
+        await persistSyncReport({
+            startedAt,
+            completedAt: new Date(),
+            force,
+            status: SYNC_REPORT_STATUS.success,
+            result
+        });
         console.log('sync-music done');
         emitSyncMessage(socket, 'done');
 
         return result;
     } catch (error) {
         console.error(error);
+        await persistSyncReport({
+            startedAt,
+            completedAt: new Date(),
+            force,
+            status: SYNC_REPORT_STATUS.error,
+            result: {
+                scannedFiles: 0,
+                indexedFiles: 0,
+                created: [],
+                moved: [],
+                duplicate: [],
+                missing: []
+            }
+        }).catch((reportError) => {
+            console.error(reportError);
+        });
         emitSyncMessage(socket, 'error');
         return null;
     }


### PR DESCRIPTION
## :dart: Goal
Expose a recent sync report that operators can read and trust after track identity classification starts making move, duplicate, and missing decisions.

## :hammer_and_wrench: Core Changes
- Add `SyncReport` and `SyncReportItem` persistence with a Prisma migration so each sync stores its summary counts and item-level details.
- Extend `sync.ts` to save `created`, `moved`, `duplicate`, and `missing` entries, including previous path data for moved tracks.
- Add a new `latestSyncReport` GraphQL query and server schema module for recent sync report access.
- Add client-side sync report types and API wiring.
- Update the settings synchronization section to show the latest sync status, started/completed times, summary counts, and expandable detail groups.
- Extend `sync.test.ts` to verify sync report persistence alongside move/duplicate/missing behavior.

## :brain: Key Decisions
- Persist reports in the database instead of memory so the most recent sync result survives server restarts and remains inspectable.
- Keep the first release focused on the latest sync report rather than a full history screen; this satisfies the trust/debugging requirement without expanding surface area too early.
- Store item-level snapshots such as `musicName` and `previousFilePath` in report items so the report remains understandable even when library visibility is filtered to active tracks.
- Reuse the existing settings sync entry point as the first report surface, because it is already where operators trigger sync and expect feedback.

## :test_tube: Verification Guide
- `cd server/src && npx prisma generate`
  - Expected: Prisma client regenerates successfully for the new sync report models.
- `cd server/src && pnpm test`
  - Expected: all Jest suites pass, including `src/socket/sync.test.ts` report persistence checks.
- `cd server/src && pnpm build`
  - Expected: server TypeScript build passes.
- `cd server/src && pnpm lint`
  - Expected: ESLint exits successfully. Existing `no-console` warnings remain in older server files, but no lint errors are introduced.
- `cd server/src/client && pnpm build`
  - Expected: client build passes and the settings page compiles with the new sync report card.
- `cd server/src/client && pnpm lint`
  - Expected: client ESLint passes.
- Manual check: open Settings, run sync, and inspect the Synchronization section.
  - Expected: the latest sync report shows status, started/completed times, counts, and expandable details for each result group.

## :white_check_mark: Checklist
- [x] Local validation for changed scope completed
- [x] PR title follows `<emoji> <subject>`
- [x] No unrelated user changes were included
- [x] Schema and migration changes are included in this branch
- [x] Ready for review