### PR TITLE
🐛 Fix album artwork cache safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,12 @@
 
 Before starting any task:
 1. If Ocean Brain MCP is available, read the Ocean Brain note titled `README AGENT` first.
-2. Follow the note to decide which additional documents are relevant to the current task.
-3. For development tasks, always read `docs/process/DEV_CONVENTION.md` and `docs/process/GIT_CONVENTION.md`.
-4. In the first response, briefly state which docs/notes were read.
-5. If Ocean Brain MCP is unavailable, continue with the local repository docs without blocking.
+2. Treat Ocean Brain notes as the primary source of agent guidance. Do not manage duplicated agent-guidance documents locally when the same guidance can live in Ocean Brain.
+3. Follow the `README AGENT` note to decide which additional notes or local repository documents are relevant to the current task.
+4. For brainstorming or ideation tasks, if Ocean Brain MCP is available, read the note titled `AI 브레인스토밍 가이드 V1`.
+5. For implementation planning tasks, if Ocean Brain MCP is available, read the note titled `AI 구현 계획 가이드 V1`.
+6. For implementation or bug-fix tasks, if Ocean Brain MCP is available, read the note titled `AI 구현 실행 가이드 V1`.
+7. For development tasks, always read `docs/process/DEV_CONVENTION.md` and `docs/process/GIT_CONVENTION.md`.
+8. For review tasks, if Ocean Brain MCP is available, read the note titled `AI 리뷰 가이드 V1`.
+9. In the first response, briefly state which docs/notes were read.
+10. If Ocean Brain MCP is unavailable, continue with the local repository docs without blocking.

--- a/server/src/client/src/components/album/AlbumSummary/AlbumSummary.tsx
+++ b/server/src/client/src/components/album/AlbumSummary/AlbumSummary.tsx
@@ -5,6 +5,7 @@ const cx = classNames.bind(styles);
 import { Link } from 'react-router-dom';
 
 import { Image, Text } from '~/components/shared';
+import { getOriginalImage } from '~/modules/image';
 
 import type { Album } from '~/models/type';
 
@@ -20,7 +21,7 @@ const AlbumSummary = ({
         <div className={cx('AlbumSummary')}>
             <div className={cx('cover')}>
                 <div className={cx('cover-inner')}>
-                    <Image src={cover.replace('/resized', '') || ''} alt={name} />
+                    <Image src={getOriginalImage(cover)} alt={name} />
                 </div>
             </div>
             <Text as="h1" size="2xl" weight="bold" className={cx('title')}>

--- a/server/src/client/src/components/layout/TwoToneLayout/TwoToneLayout.tsx
+++ b/server/src/client/src/components/layout/TwoToneLayout/TwoToneLayout.tsx
@@ -4,6 +4,8 @@ const cx = classNames.bind(styles);
 
 import React from 'react';
 
+import { Image } from '~/components/shared';
+
 interface TwoToneLayoutProps {
     backgroundImage?: string;
     header: React.ReactNode;
@@ -21,7 +23,7 @@ const TwoToneLayout = ({
         <div className={cx('TwoToneLayout', { hasPrimaryAction: !!primaryAction })}>
             {backgroundImage && (
                 <div className={cx('background')}>
-                    <img src={backgroundImage} alt="" aria-hidden="true" />
+                    <Image src={backgroundImage} alt="" aria-hidden="true" loading="eager" />
                     <div className={cx('overlay')} />
                 </div>
             )}

--- a/server/src/client/src/components/music/MusicPlayerDiskStyle/MusicPlayerDiskStyle.tsx
+++ b/server/src/client/src/components/music/MusicPlayerDiskStyle/MusicPlayerDiskStyle.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames/bind';
 const cx = classNames.bind(styles);
 
 import { Image } from '~/components/shared';
+import { getOriginalImage } from '~/modules/image';
 
 interface MusicPlayerDiskStyleProps {
     isPlaying: boolean;
@@ -13,15 +14,16 @@ interface MusicPlayerDiskStyleProps {
 const MusicPlayerDiskStyle = ({ isPlaying, src, alt }: MusicPlayerDiskStyleProps) => {
     return (
         <div className={cx('MusicPlayerDiskStyle')}>
-            <img
+            <Image
                 className={cx('background')}
                 src={src}
                 alt={alt}
+                loading="eager"
             />
             <div className={cx('foreground-wrapper')}>
                 <Image
                     className={cx('foreground', { isPlaying })}
-                    src={src.replace('/resized', '')}
+                    src={getOriginalImage(src)}
                     alt={alt}
                 />
             </div>

--- a/server/src/client/src/components/music/MusicPlayerFluffyStyle/MusicPlayerFluffyStyle.tsx
+++ b/server/src/client/src/components/music/MusicPlayerFluffyStyle/MusicPlayerFluffyStyle.tsx
@@ -4,6 +4,7 @@ const cx = classNames.bind(styles);
 
 import { useEffect, useState } from 'react';
 import { Image } from '~/components/shared';
+import { getOriginalImage } from '~/modules/image';
 
 interface MusicPlayerFluffyStyleProps {
     isPlaying: boolean;
@@ -41,17 +42,18 @@ const MusicPlayerFluffyStyle = ({ isPlaying, src, alt }: MusicPlayerFluffyStyleP
 
     return (
         <div className={cx('MusicPlayerFluffyStyle')}>
-            <img
+            <Image
                 className={cx('background')}
                 style={{ borderRadius }}
                 src={src}
                 alt={alt}
+                loading="eager"
             />
             <div className={cx('foreground-wrapper')}>
                 <Image
                     className={cx('foreground')}
                     style={{ borderRadius }}
-                    src={src.replace('/resized', '')}
+                    src={getOriginalImage(src)}
                     alt={alt}
                 />
             </div>

--- a/server/src/client/src/components/music/MusicPlayerVisualizerStyle/MusicPlayerVisualizerStyle.tsx
+++ b/server/src/client/src/components/music/MusicPlayerVisualizerStyle/MusicPlayerVisualizerStyle.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef } from 'react';
 const cx = classNames.bind(styles);
 
 import { Image } from '~/components/shared';
+import { getOriginalImage } from '~/modules/image';
 import { webAudioContext } from '~/modules/web-audio-context';
 
 import {
@@ -82,7 +83,7 @@ const MusicPlayerVisualizerStyle = ({ type, isPlaying, src, alt }: MusicPlayerVi
             <div className={cx('foreground-wrapper')}>
                 <Image
                     className={cx('foreground', { isPlaying })}
-                    src={src.replace('/resized', '')}
+                    src={getOriginalImage(src)}
                     alt={alt}
                 />
             </div>

--- a/server/src/client/src/components/shared/Image.tsx
+++ b/server/src/client/src/components/shared/Image.tsx
@@ -1,22 +1,40 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type ImgHTMLAttributes, type ReactEventHandler } from 'react';
 import { getImage } from '~/modules/image';
 
-interface ImageProps {
+const PLACEHOLDER_IMAGE =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NQV1f/DwACYwF11mMyYQAAAABJRU5ErkJggg==';
+const FALLBACK_APPLIED_FLAG = 'fallbackApplied';
+
+interface ImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> {
     src?: string;
-    alt?: string;
-    style?: React.CSSProperties;
     loading?: 'lazy' | 'eager';
-    className?: string;
 }
 
 export default function Image({
     src,
-    alt,
-    style,
     loading = 'lazy',
-    className
+    onError,
+    ...props
 }: ImageProps) {
     const ref = useRef<HTMLImageElement>(null);
+
+    const handleError: ReactEventHandler<HTMLImageElement> = (event) => {
+        onError?.(event);
+
+        const image = event.currentTarget;
+        if (image.dataset[FALLBACK_APPLIED_FLAG] === 'true') {
+            return;
+        }
+
+        image.dataset[FALLBACK_APPLIED_FLAG] = 'true';
+        image.src = getImage();
+    };
+
+    useEffect(() => {
+        if (ref.current) {
+            delete ref.current.dataset[FALLBACK_APPLIED_FLAG];
+        }
+    }, [src]);
 
     useEffect(() => {
         if (!ref.current || loading !== 'lazy') {
@@ -41,14 +59,20 @@ export default function Image({
     return (
         <>
             {loading !== 'lazy' ? (
-                <img src={getImage(src)} alt={alt} style={style} className={className} />
+                <img
+                    ref={ref}
+                    src={getImage(src)}
+                    loading={loading}
+                    onError={handleError}
+                    {...props}
+                />
             ) : (
                 <img
                     ref={ref}
-                    src={'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NQV1f/DwACYwF11mMyYQAAAABJRU5ErkJggg=='}
-                    alt={alt}
-                    style={style}
-                    className={className}
+                    src={PLACEHOLDER_IMAGE}
+                    loading={loading}
+                    onError={handleError}
+                    {...props}
                 />
             )}
         </>

--- a/server/src/client/src/modules/image.test.ts
+++ b/server/src/client/src/modules/image.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { getImage, getOriginalImage } from './image';
+
+describe('getImage', () => {
+    it('returns the default artwork when the source is empty', () => {
+        expect(getImage()).toBe('/images/ocean-wave.jpg');
+        expect(getImage('')).toBe('/images/ocean-wave.jpg');
+    });
+
+    it('returns the provided source when it exists', () => {
+        expect(getImage('/cache/resized/42.jpg')).toBe('/cache/resized/42.jpg');
+    });
+});
+
+describe('getOriginalImage', () => {
+    it('keeps the default artwork path intact', () => {
+        expect(getOriginalImage()).toBe('/images/ocean-wave.jpg');
+    });
+
+    it('removes the resized path segment for original artwork surfaces', () => {
+        expect(getOriginalImage('/cache/resized/42.jpg')).toBe('/cache/42.jpg');
+    });
+});

--- a/server/src/client/src/modules/image.ts
+++ b/server/src/client/src/modules/image.ts
@@ -1,8 +1,14 @@
 import { appCopy } from '~/config/copy';
 
+const RESIZED_SEGMENT = '/resized';
+
 export const getImage = (src?: string) => {
     if (!src) {
         return appCopy.media.defaultArtworkPath;
     }
     return src;
+};
+
+export const getOriginalImage = (src?: string) => {
+    return getImage(src).replace(RESIZED_SEGMENT, '');
 };

--- a/server/src/client/src/pages/AlbumDetail.tsx
+++ b/server/src/client/src/pages/AlbumDetail.tsx
@@ -9,6 +9,7 @@ import { Play } from '~/icon';
 
 import { getAlbum } from '~/api';
 
+import { getOriginalImage } from '~/modules/image';
 import { musicStore } from '~/store/music';
 import { queueStore } from '~/store/queue';
 import { panel } from '~/modules/panel';
@@ -31,7 +32,7 @@ export default function AlbumDetail() {
 
     return (
         <TwoToneLayout
-            backgroundImage={album.cover.replace('/resized', '')}
+            backgroundImage={album.cover ? getOriginalImage(album.cover) : undefined}
             header={(
                 <AlbumSummary {...album} />
             )}

--- a/server/src/client/src/pages/Player.tsx
+++ b/server/src/client/src/pages/Player.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { useStore } from 'badland-react';
 
 import { MusicPlayerDiskStyle, MusicPlayerFluffyStyle, MusicPlayerVisualizerStyle } from '~/components/music';
-import { Text } from '~/components/shared';
+import { Image, Text } from '~/components/shared';
 import * as Icon from '~/icon';
 
 import { useBack, useStoreValue } from '~/hooks';
@@ -103,7 +103,12 @@ export default function PlayerDetail() {
         <div className={cx('Player')}>
             {currentMusic && showBackground && (
                 <div className={cx('background')}>
-                    <img src={getImage(currentMusic.album.cover)} alt="" aria-hidden="true" />
+                    <Image
+                        src={currentMusic.album.cover}
+                        alt=""
+                        aria-hidden="true"
+                        loading="eager"
+                    />
                     <div className={cx('overlay')} />
                 </div>
             )}

--- a/server/src/script/_test.ts
+++ b/server/src/script/_test.ts
@@ -10,7 +10,7 @@ const main = async () => {
     try {
         await removeDatabase(fileName);
         await createDatabase();
-        childProcess.execSync('jest --coverage', {
+        childProcess.execSync('jest --coverage --runInBand', {
             stdio: 'inherit',
         });
     } catch (e) {

--- a/server/src/src/app.ts
+++ b/server/src/src/app.ts
@@ -8,17 +8,25 @@ import {
 } from './modules/auth';
 import { resolveAuthConfig, type AuthConfig } from './modules/auth-mode';
 import logger from './modules/logger';
+import { resolveCachePath } from './modules/storage-paths';
+import useAsync from './modules/use-async';
 import schema from './schema';
 import { createApiRouter } from './urls';
+import { cacheAsset } from './views';
 
 export const createApp = (authConfig: AuthConfig = resolveAuthConfig(process.env)) => {
     return express()
         .use(logger)
         .use(express.static(path.resolve('client/dist'), { extensions: ['html'] }))
-        .use('/cache', requireAuthenticatedRequest(authConfig), express.static(path.resolve('cache'), {
-            cacheControl: true,
-            maxAge: 31536000
-        }))
+        .use(
+            '/cache',
+            requireAuthenticatedRequest(authConfig),
+            useAsync(cacheAsset),
+            express.static(resolveCachePath(), {
+                cacheControl: true,
+                maxAge: 31536000
+            })
+        )
         .use(express.json())
         .use('/graphql', requireAuthenticatedGraphqlRequest(authConfig), createHandler({ schema }))
         .use('/api', createApiRouter(authConfig))

--- a/server/src/src/modules/album-cover-cache.ts
+++ b/server/src/src/modules/album-cover-cache.ts
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import path from 'path';
+import sharp from 'sharp';
+
+export const ALBUM_COVER_CACHE_PREFIX = '/cache/resized/';
+
+const ensureDirectory = (directoryPath: string) => {
+    if (!fs.existsSync(directoryPath)) {
+        fs.mkdirSync(directoryPath, { recursive: true });
+    }
+};
+
+export const getAlbumCoverFileName = (albumId: number) => {
+    return `${albumId}.jpg`;
+};
+
+export const getAlbumCoverPath = (albumId: number) => {
+    return `${ALBUM_COVER_CACHE_PREFIX}${getAlbumCoverFileName(albumId)}`;
+};
+
+export const parseAlbumIdFromCoverRequestPath = (requestPath: string) => {
+    const match = requestPath.match(/^\/resized\/(\d+)\.jpg$/);
+
+    if (!match) {
+        return null;
+    }
+
+    const albumId = Number(match[1]);
+
+    return Number.isInteger(albumId)
+        ? albumId
+        : null;
+};
+
+export const hasHealthyAlbumCoverCache = ({
+    coverPath,
+    cachePath,
+    resizedPath
+}: {
+    coverPath: string;
+    cachePath: string;
+    resizedPath: string;
+}) => {
+    if (!coverPath.startsWith(ALBUM_COVER_CACHE_PREFIX)) {
+        return true;
+    }
+
+    const fileName = path.basename(coverPath);
+
+    return (
+        fs.existsSync(path.join(cachePath, fileName))
+        && fs.existsSync(path.join(resizedPath, fileName))
+    );
+};
+
+export const syncAlbumCoverCache = async ({
+    albumId,
+    currentCoverPath,
+    pictureData,
+    cachePath,
+    resizedPath
+}: {
+    albumId: number;
+    currentCoverPath: string;
+    pictureData: Buffer | null;
+    cachePath: string;
+    resizedPath: string;
+}) => {
+    if (!pictureData) {
+        return currentCoverPath;
+    }
+
+    ensureDirectory(cachePath);
+    ensureDirectory(resizedPath);
+
+    const fileName = getAlbumCoverFileName(albumId);
+    const savePath = path.join(cachePath, fileName);
+    const resizedSavePath = path.join(resizedPath, fileName);
+    const hasOriginalCache = fs.existsSync(savePath);
+    const shouldUpdate = !hasOriginalCache || !fs.readFileSync(savePath).equals(pictureData);
+
+    if (shouldUpdate) {
+        fs.writeFileSync(savePath, pictureData);
+    }
+
+    if (!fs.existsSync(resizedSavePath) || shouldUpdate) {
+        await sharp(savePath)
+            .resize(300, 300)
+            .toFile(resizedSavePath);
+    }
+
+    return getAlbumCoverPath(albumId);
+};

--- a/server/src/src/modules/storage-paths.ts
+++ b/server/src/src/modules/storage-paths.ts
@@ -1,0 +1,7 @@
+import path from 'path';
+
+export const resolveCachePath = () => {
+    return process.env.OCEAN_WAVE_CACHE_PATH
+        ? path.resolve(process.env.OCEAN_WAVE_CACHE_PATH)
+        : path.resolve('./cache');
+};

--- a/server/src/src/schema/album/index.test.ts
+++ b/server/src/src/schema/album/index.test.ts
@@ -1,0 +1,21 @@
+import { albumResolvers } from './index';
+
+describe('album cover resolver', () => {
+    it('returns the canonical cover route from album id', () => {
+        const cover = (albumResolvers.Album as { cover: (album: { id: number; cover: string }) => string }).cover({
+            id: 42,
+            cover: '/cache/resized/999.jpg'
+        });
+
+        expect(cover).toBe('/cache/resized/42.jpg');
+    });
+
+    it('keeps empty cover values empty', () => {
+        const cover = (albumResolvers.Album as { cover: (album: { id: number; cover: string }) => string }).cover({
+            id: 42,
+            cover: ''
+        });
+
+        expect(cover).toBe('');
+    });
+});

--- a/server/src/src/schema/album/index.ts
+++ b/server/src/src/schema/album/index.ts
@@ -1,6 +1,7 @@
 import type { IResolvers } from '@graphql-tools/utils';
 
 import models, { type Album } from '~/models';
+import { getAlbumCoverPath } from '~/modules/album-cover-cache';
 import { gql } from '~/modules/graphql';
 import { TRACK_SYNC_STATUS } from '~/modules/track-identity';
 import { artistType } from '../artist';
@@ -43,6 +44,11 @@ export const albumResolvers: IResolvers = {
         album: (_, { id }: Album) => models.album.findUnique({ where: { id: Number(id) } })
     },
     Album: {
+        cover: (album: Album) => {
+            return album.cover
+                ? getAlbumCoverPath(album.id)
+                : '';
+        },
         artist: (album: Album) => models.artist.findUnique({ where: { id: album.artistId } }),
         musics: (album: Album) => models.music.findMany({
             where: {

--- a/server/src/src/socket/sync.test.ts
+++ b/server/src/src/socket/sync.test.ts
@@ -13,11 +13,14 @@ jest.mock('music-metadata', () => ({ parseBuffer: jest.fn() }));
 jest.mock('sharp', () => {
     return jest.fn(() => ({
         resize: jest.fn().mockReturnThis(),
-        toFile: jest.fn().mockResolvedValue(undefined)
+        toFile: jest.fn().mockImplementation(async (outputPath: string) => {
+            fs.writeFileSync(outputPath, 'resized-artwork');
+        })
     }));
 });
 
 import { walk } from '../modules/file';
+import { resolveCachePath } from '../modules/storage-paths';
 import { TRACK_CONTENT_HASH_VERSION, createTrackContentHash } from '../modules/track-hash';
 import { SYNC_REPORT_KIND, SYNC_REPORT_STATUS } from '../modules/sync-report';
 import { TRACK_SYNC_STATUS } from '../modules/track-identity';
@@ -33,6 +36,7 @@ const createTrackFixture = (overrides?: {
     year?: string;
     trackNumber?: number;
     fingerprint?: string;
+    picture?: string;
 }) => {
     const title = overrides?.title ?? 'Track A';
     const artist = overrides?.artist ?? 'Artist A';
@@ -40,8 +44,9 @@ const createTrackFixture = (overrides?: {
     const year = overrides?.year ?? '2026';
     const trackNumber = overrides?.trackNumber ?? 1;
     const fingerprint = overrides?.fingerprint ?? 'fingerprint-a';
+    const picture = overrides?.picture ?? '';
 
-    return `title=${title}|artist=${artist}|album=${album}|year=${year}|track=${trackNumber}|fingerprint=${fingerprint}`;
+    return `title=${title}|artist=${artist}|album=${album}|year=${year}|track=${trackNumber}|fingerprint=${fingerprint}|picture=${picture}`;
 };
 
 const createTempTrackFile = ({
@@ -103,6 +108,8 @@ const createExistingMusic = async ({
 
 describe('sync music identity', () => {
     const tempDirectories: string[] = [];
+    const workspaceDirectories: string[] = [];
+    const originalCachePath = process.env.OCEAN_WAVE_CACHE_PATH;
 
     beforeEach(async () => {
         jest.restoreAllMocks();
@@ -125,12 +132,24 @@ describe('sync music identity', () => {
                     title: entries.title,
                     artist: entries.artist,
                     album: entries.album,
+                    picture: entries.picture
+                        ? [
+                            {
+                                data: Buffer.from(entries.picture),
+                                format: 'image/jpeg'
+                            }
+                        ]
+                        : [],
                     genre: [],
                     year: Number(entries.year),
                     track: { no: Number(entries.track) }
                 }
             } as never;
         });
+
+        const workspaceDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'beato-sync-workspace-'));
+        workspaceDirectories.push(workspaceDirectory);
+        process.env.OCEAN_WAVE_CACHE_PATH = path.join(workspaceDirectory, 'cache');
 
         await models.playbackEvent.deleteMany();
         await models.syncReportItem.deleteMany();
@@ -146,6 +165,8 @@ describe('sync music identity', () => {
     });
 
     afterEach(() => {
+        process.env.OCEAN_WAVE_CACHE_PATH = originalCachePath;
+
         while (tempDirectories.length > 0) {
             fs.rmSync(tempDirectories.pop()!, {
                 recursive: true,
@@ -153,10 +174,12 @@ describe('sync music identity', () => {
             });
         }
 
-        fs.rmSync(path.resolve('./cache'), {
-            recursive: true,
-            force: true
-        });
+        while (workspaceDirectories.length > 0) {
+            fs.rmSync(workspaceDirectories.pop()!, {
+                recursive: true,
+                force: true
+            });
+        }
     });
 
     it('moves a track to a new path without losing linked data', async () => {
@@ -285,6 +308,46 @@ describe('sync music identity', () => {
                 musicName: musics[1].name
             })
         ]));
+    });
+
+    it('repairs missing cached album artwork for unchanged tracks during normal sync', async () => {
+        const contents = createTrackFixture({
+            fingerprint: 'cover-repair-hash',
+            picture: 'cover-art-a'
+        });
+        const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'beato-sync-cover-repair-'));
+        tempDirectories.push(tempDirectory);
+
+        const existingPath = createTempTrackFile({
+            directory: tempDirectory,
+            relativePath: 'library/track-a.mp3',
+            contents
+        });
+        const existingMusic = await createExistingMusic({
+            filePath: existingPath,
+            contents
+        });
+
+        await models.album.update({
+            where: { id: existingMusic.albumId },
+            data: { cover: `/cache/resized/${existingMusic.albumId}.jpg` }
+        });
+
+        walkMock.mockResolvedValue([existingPath]);
+
+        const result = await syncMusic({ emit: jest.fn() } as never);
+        const album = await models.album.findUniqueOrThrow({ where: { id: existingMusic.albumId } });
+
+        expect(result).toMatchObject({
+            created: [],
+            moved: [],
+            duplicate: [],
+            missing: []
+        });
+        expect(parseBufferMock).toHaveBeenCalledTimes(1);
+        expect(album.cover).toBe(`/cache/resized/${existingMusic.albumId}.jpg`);
+        expect(fs.existsSync(path.join(resolveCachePath(), `${existingMusic.albumId}.jpg`))).toBe(true);
+        expect(fs.existsSync(path.join(resolveCachePath(), 'resized', `${existingMusic.albumId}.jpg`))).toBe(true);
     });
 
     it('marks unseen tracks as missing instead of deleting them', async () => {

--- a/server/src/src/socket/sync.ts
+++ b/server/src/src/socket/sync.ts
@@ -2,11 +2,15 @@ import fs from 'fs';
 import path from 'path';
 import type { Socket } from 'socket.io';
 import { parseBuffer } from 'music-metadata';
-import sharp from 'sharp';
 
 import { connectors } from './connectors';
 
+import {
+    hasHealthyAlbumCoverCache,
+    syncAlbumCoverCache
+} from '../modules/album-cover-cache';
 import { walk } from '../modules/file';
+import { resolveCachePath } from '../modules/storage-paths';
 import {
     TRACK_CONTENT_HASH_VERSION,
     createTrackContentHash,
@@ -183,51 +187,6 @@ const findOrCreateGenres = async (genreNames: string[]): Promise<Genre[]> => {
     }));
 };
 
-const syncAlbumCover = async ({
-    album,
-    pictureData,
-    cachePath,
-    resizedPath
-}: {
-    album: Album;
-    pictureData: Buffer | null;
-    cachePath: string;
-    resizedPath: string;
-}) => {
-    if (!pictureData) {
-        return album.cover;
-    }
-
-    const fileName = `${album.id}.jpg`;
-    const savePath = path.join(cachePath, fileName);
-
-    const hasCache = fs.existsSync(savePath);
-    const shouldUpdate = hasCache && (
-        fs.readFileSync(savePath).toString() !== pictureData.toString()
-    );
-
-    if (!hasCache || shouldUpdate) {
-        fs.writeFileSync(savePath, pictureData);
-    }
-
-    const resizedSavePath = path.join(resizedPath, fileName);
-    if (!fs.existsSync(resizedSavePath) || shouldUpdate) {
-        await sharp(savePath)
-            .resize(300, 300)
-            .toFile(resizedSavePath);
-    }
-
-    const coverPath = `/cache/resized/${fileName}`;
-    if (album.cover !== coverPath) {
-        await models.album.update({
-            where: { id: album.id },
-            data: { cover: coverPath }
-        });
-    }
-
-    return coverPath;
-};
-
 const upsertMusicFromMetadata = async ({
     existingMusic,
     filePath,
@@ -258,12 +217,20 @@ const upsertMusicFromMetadata = async ({
     });
     const genres = await findOrCreateGenres(metadata.genres);
 
-    await syncAlbumCover({
-        album,
+    const coverPath = await syncAlbumCoverCache({
+        albumId: album.id,
+        currentCoverPath: album.cover,
         pictureData: metadata.pictureData,
         cachePath,
         resizedPath
     });
+
+    if (album.cover !== coverPath) {
+        await models.album.update({
+            where: { id: album.id },
+            data: { cover: coverPath }
+        });
+    }
 
     if (existingMusic) {
         return models.music.update({
@@ -324,6 +291,46 @@ const updateMusicIdentity = async ({
             contentHash,
             hashVersion: TRACK_CONTENT_HASH_VERSION
         }
+    });
+};
+
+const repairAlbumCoverCacheIfNeeded = async ({
+    music,
+    filePath,
+    fileData,
+    cachePath,
+    resizedPath,
+    albumById
+}: {
+    music: Music;
+    filePath: string;
+    fileData: Buffer | null;
+    cachePath: string;
+    resizedPath: string;
+    albumById: Map<number, Album>;
+}) => {
+    const album = albumById.get(music.albumId);
+
+    if (!album || !album.cover || hasHealthyAlbumCoverCache({
+        coverPath: album.cover,
+        cachePath,
+        resizedPath
+    })) {
+        return;
+    }
+
+    const metadata = await parseTrackMetadata(filePath, fileData ?? fs.readFileSync(filePath));
+    const coverPath = await syncAlbumCoverCache({
+        albumId: album.id,
+        currentCoverPath: album.cover,
+        pictureData: metadata.pictureData,
+        cachePath,
+        resizedPath
+    });
+
+    albumById.set(album.id, {
+        ...album,
+        cover: coverPath
     });
 };
 
@@ -439,15 +446,17 @@ export const syncMusic = async (socket: Pick<Socket, 'emit'>, force = false): Pr
         console.log(`find ${files.length} files`);
         emitSyncMessage(socket, `find ${files.length} files`);
 
-        const cachePath = path.resolve('./cache');
+        const cachePath = resolveCachePath();
         const resizedPath = path.join(cachePath, 'resized');
         ensureDirectory(cachePath);
         ensureDirectory(resizedPath);
 
         const musics = await models.music.findMany({ orderBy: { id: 'asc' } });
+        const albums = await models.album.findMany({ orderBy: { id: 'asc' } });
         const musicById = new Map(musics.map((music) => [music.id, music]));
         const musicByPath = new Map(musics.map((music) => [music.filePath, music]));
         const identityRecordById = new Map(musics.map((music) => [music.id, toTrackIdentityRecord(music)]));
+        const albumById = new Map(albums.map((album) => [album.id, album]));
         const indexedFiles = files.filter((filePath) => {
             const music = musicByPath.get(filePath);
 
@@ -530,6 +539,15 @@ export const syncMusic = async (socket: Pick<Socket, 'emit'>, force = false): Pr
                     });
                     upsertKnownMusic(updatedMusic);
                 }
+
+                await repairAlbumCoverCacheIfNeeded({
+                    music: pathMatch,
+                    filePath,
+                    fileData,
+                    cachePath,
+                    resizedPath,
+                    albumById
+                });
 
                 continue;
             }

--- a/server/src/src/views/cache/cache.test.ts
+++ b/server/src/src/views/cache/cache.test.ts
@@ -1,0 +1,147 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parseBuffer } from 'music-metadata';
+import request from 'supertest';
+
+import models from '~/models';
+import { createApp } from '~/app';
+import { resolveCachePath } from '~/modules/storage-paths';
+
+jest.mock('music-metadata', () => ({ parseBuffer: jest.fn() }));
+
+jest.mock('sharp', () => {
+    return jest.fn(() => ({
+        resize: jest.fn().mockReturnThis(),
+        toFile: jest.fn().mockImplementation(async (outputPath: string) => {
+            fs.writeFileSync(outputPath, 'resized-artwork');
+        })
+    }));
+});
+
+const parseBufferMock = jest.mocked(parseBuffer);
+
+const createTempTrackFile = ({
+    directory,
+    relativePath,
+    contents
+}: {
+    directory: string;
+    relativePath: string;
+    contents: string;
+}) => {
+    const absolutePath = path.join(directory, relativePath);
+
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, contents);
+
+    return absolutePath;
+};
+
+describe('GET /cache/resized/:albumId.jpg', () => {
+    const tempDirectories: string[] = [];
+    const workspaceDirectories: string[] = [];
+    const originalCachePath = process.env.OCEAN_WAVE_CACHE_PATH;
+
+    beforeEach(async () => {
+        jest.restoreAllMocks();
+        parseBufferMock.mockReset();
+        parseBufferMock.mockImplementation(async (data) => {
+            const entries = Object.fromEntries(
+                data.toString().split('|').map((entry) => entry.split('='))
+            );
+
+            return {
+                format: {},
+                common: {
+                    picture: entries.picture
+                        ? [
+                            {
+                                data: Buffer.from(entries.picture),
+                                format: 'image/jpeg'
+                            }
+                        ]
+                        : []
+                }
+            } as never;
+        });
+
+        const workspaceDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'beato-cache-view-workspace-'));
+        workspaceDirectories.push(workspaceDirectory);
+        process.env.OCEAN_WAVE_CACHE_PATH = path.join(workspaceDirectory, 'cache');
+
+        await models.playbackEvent.deleteMany();
+        await models.syncReportItem.deleteMany();
+        await models.syncReport.deleteMany();
+        await models.playlistMusic.deleteMany();
+        await models.playlist.deleteMany();
+        await models.musicLike.deleteMany();
+        await models.musicHate.deleteMany();
+        await models.music.deleteMany();
+        await models.album.deleteMany();
+        await models.artist.deleteMany();
+        await models.genre.deleteMany();
+    });
+
+    afterEach(() => {
+        process.env.OCEAN_WAVE_CACHE_PATH = originalCachePath;
+
+        while (tempDirectories.length > 0) {
+            fs.rmSync(tempDirectories.pop()!, {
+                recursive: true,
+                force: true
+            });
+        }
+
+        while (workspaceDirectories.length > 0) {
+            fs.rmSync(workspaceDirectories.pop()!, {
+                recursive: true,
+                force: true
+            });
+        }
+    });
+
+    it('regenerates a missing cached cover from track metadata on request', async () => {
+        const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'beato-cover-view-'));
+        tempDirectories.push(tempDirectory);
+
+        const trackPath = createTempTrackFile({
+            directory: tempDirectory,
+            relativePath: 'library/track-a.mp3',
+            contents: 'picture=cover-art-a'
+        });
+
+        const artist = await models.artist.create({ data: { name: 'Artist A' } });
+        const album = await models.album.create({
+            data: {
+                name: 'Album A',
+                cover: '/cache/resized/1.jpg',
+                publishedYear: '2026',
+                artistId: artist.id
+            }
+        });
+        await models.music.create({
+            data: {
+                name: 'Track A',
+                artistId: artist.id,
+                albumId: album.id,
+                filePath: trackPath,
+                duration: 180,
+                codec: 'mp3',
+                container: 'mp3',
+                bitrate: 320,
+                sampleRate: 44100,
+                trackNumber: 1
+            }
+        });
+
+        const app = createApp({ mode: 'open' });
+        const response = await request(app).get(`/cache/resized/${album.id}.jpg`);
+
+        expect(response.status).toBe(200);
+        expect(response.headers['content-type']).toMatch(/image\/jpeg/);
+        expect(parseBufferMock).toHaveBeenCalledTimes(1);
+        expect(fs.existsSync(path.join(resolveCachePath(), `${album.id}.jpg`))).toBe(true);
+        expect(fs.existsSync(path.join(resolveCachePath(), 'resized', `${album.id}.jpg`))).toBe(true);
+    });
+});

--- a/server/src/src/views/cache/cache.ts
+++ b/server/src/src/views/cache/cache.ts
@@ -1,0 +1,73 @@
+import fs from 'fs';
+import path from 'path';
+import { parseBuffer } from 'music-metadata';
+
+import models from '~/models';
+import type { Controller } from '~/types';
+
+import {
+    parseAlbumIdFromCoverRequestPath,
+    syncAlbumCoverCache
+} from '../../modules/album-cover-cache';
+import { resolveCachePath } from '../../modules/storage-paths';
+
+export const cacheAsset: Controller = async (req, _res, next) => {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+        next?.();
+        return;
+    }
+
+    const cachePath = resolveCachePath();
+    const requestedFilePath = path.join(cachePath, req.path);
+
+    if (fs.existsSync(requestedFilePath)) {
+        next?.();
+        return;
+    }
+
+    const albumId = parseAlbumIdFromCoverRequestPath(req.path);
+
+    if (albumId === null) {
+        next?.();
+        return;
+    }
+
+    const music = await models.music.findFirst({
+        where: { albumId },
+        orderBy: { id: 'asc' },
+        select: { filePath: true }
+    });
+
+    if (!music) {
+        next?.();
+        return;
+    }
+
+    const sourceFilePath = path.isAbsolute(music.filePath)
+        ? music.filePath
+        : path.resolve('./music', music.filePath);
+
+    if (!fs.existsSync(sourceFilePath)) {
+        next?.();
+        return;
+    }
+
+    const fileData = fs.readFileSync(sourceFilePath);
+    const metadata = await parseBuffer(fileData);
+    const pictureData = metadata.common.picture?.[0]?.data ?? null;
+
+    if (!pictureData) {
+        next?.();
+        return;
+    }
+
+    await syncAlbumCoverCache({
+        albumId,
+        currentCoverPath: req.path,
+        pictureData,
+        cachePath,
+        resizedPath: path.join(cachePath, 'resized')
+    });
+
+    next?.();
+};

--- a/server/src/src/views/cache/index.ts
+++ b/server/src/src/views/cache/index.ts
@@ -1,0 +1,1 @@
+export * from './cache';

--- a/server/src/src/views/index.ts
+++ b/server/src/src/views/index.ts
@@ -1,3 +1,4 @@
 export * from './audio';
 export * from './auth';
+export * from './cache';
 export * from './home';


### PR DESCRIPTION
## :dart: Goal
- Stop album artwork regressions caused by stale or missing cache files and keep tests from touching the real workspace cache.
- Keep client artwork surfaces pointed at the right original and resized image paths.

## :hammer_and_wrench: Core Changes
- Added shared album cover cache helpers and a cache storage path resolver, then routed `/cache` requests through regeneration middleware before static serving.
- Canonicalized GraphQL album cover output to `/cache/resized/:albumId.jpg` and repaired missing cache files during sync when an unchanged track still has embedded artwork.
- Centralized image fallback handling in the client `Image` component, added `getOriginalImage`, and updated album and player artwork surfaces to use the correct original or resized source.
- Isolated sync and cache tests from real workspace assets via `OCEAN_WAVE_CACHE_PATH`, added server tests for canonical cover routing and on-demand cache regeneration, added client tests for image helpers, and ran server tests in band to avoid shared cache collisions.
- Updated `AGENTS.md` so agent guidance points to Ocean Brain first when it is available.

## :brain: Key Decisions
- Treated real cache deletion as the root guardrail issue and moved tests to temp workspace paths instead of letting cleanup touch `server/src/cache`.
- Kept recovery as a safety net so the server can rebuild a missing cover cache file from embedded track artwork after an external accident.
- Returned cover URLs from `album.id` instead of trusting a stale stored cache filename so the API surface stays stable.

## :test_tube: Verification Guide
- `cd server/src && pnpm lint`
  Expected: exits 0; current `no-console` warnings remain but there are no lint errors.
- `cd server/src && pnpm build`
  Expected: TypeScript build succeeds.
- `cd server/src && pnpm test`
  Expected: 8 suites and 22 tests pass.
- `cd server/src/client && pnpm lint`
  Expected: exits 0.
- `cd server/src/client && pnpm build`
  Expected: Vite production build succeeds.
- `cd server/src/client && pnpm test -- --run src/modules/image.test.ts`
  Expected: client tests pass, including `src/modules/image.test.ts`.

## :white_check_mark: Checklist
- [x] Title follows `<emoji> <subject>`.
- [x] Local validation for the changed scope is complete.
- [x] Test cleanup no longer deletes the real workspace cache.
- [x] Docs, script, and env changes are documented in this PR body (`AGENTS.md`, `OCEAN_WAVE_CACHE_PATH`, `server/src/script/_test.ts`).
- [ ] Release-impacting changes are included.
