### PR TITLE
✨ Add playback checkpoint recovery flow

### DIFF
--- a/server/src/client/src/App.tsx
+++ b/server/src/client/src/App.tsx
@@ -118,7 +118,10 @@ export default function App() {
 
     useEffect(() => {
         const handleConnect = () => {
-            void MusicListener.count();
+            void (async () => {
+                await MusicListener.count();
+                await MusicListener.recoverPlaybackCheckpoints();
+            })();
         };
 
         const handleWindowFocus = () => {

--- a/server/src/client/src/modules/playback-checkpoint-store.test.ts
+++ b/server/src/client/src/modules/playback-checkpoint-store.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    clearPlaybackCheckpoints,
+    deletePlaybackCheckpoint,
+    getPlaybackCheckpoint,
+    listPlaybackCheckpoints,
+    savePlaybackCheckpoint
+} from './playback-checkpoint-store';
+
+const createCheckpoint = (overrides?: Partial<Parameters<typeof savePlaybackCheckpoint>[0]>) => ({
+    clientSessionId: overrides?.clientSessionId ?? 'session-1',
+    trackId: overrides?.trackId ?? 'track-1',
+    startedAt: overrides?.startedAt ?? '2026-04-10T10:00:00.000Z',
+    accumulatedPlayedMs: overrides?.accumulatedPlayedMs ?? 12_000,
+    lastResumedAt: overrides?.lastResumedAt ?? '2026-04-10T10:00:05.000Z',
+    active: overrides?.active ?? true,
+    updatedAt: overrides?.updatedAt ?? '2026-04-10T10:00:12.000Z',
+    source: overrides?.source ?? 'queue-checkpoint'
+});
+
+describe('playback checkpoint store', () => {
+    beforeEach(async () => {
+        await clearPlaybackCheckpoints();
+    });
+
+    it('saves and restores a checkpoint by client session id', async () => {
+        const checkpoint = createCheckpoint();
+
+        await savePlaybackCheckpoint(checkpoint);
+
+        expect(await getPlaybackCheckpoint(checkpoint.clientSessionId)).toEqual(checkpoint);
+    });
+
+    it('overwrites an existing checkpoint with the latest snapshot', async () => {
+        await savePlaybackCheckpoint(createCheckpoint());
+        await savePlaybackCheckpoint(createCheckpoint({
+            accumulatedPlayedMs: 24_000,
+            active: false,
+            updatedAt: '2026-04-10T10:00:24.000Z',
+            source: 'queue-pause'
+        }));
+
+        expect(await getPlaybackCheckpoint('session-1')).toEqual(createCheckpoint({
+            accumulatedPlayedMs: 24_000,
+            active: false,
+            updatedAt: '2026-04-10T10:00:24.000Z',
+            source: 'queue-pause'
+        }));
+    });
+
+    it('lists checkpoints in update order and removes deleted entries', async () => {
+        await savePlaybackCheckpoint(createCheckpoint({
+            clientSessionId: 'session-2',
+            updatedAt: '2026-04-10T10:00:20.000Z'
+        }));
+        await savePlaybackCheckpoint(createCheckpoint({
+            clientSessionId: 'session-1',
+            updatedAt: '2026-04-10T10:00:10.000Z'
+        }));
+
+        expect(await listPlaybackCheckpoints()).toEqual([
+            createCheckpoint({
+                clientSessionId: 'session-1',
+                updatedAt: '2026-04-10T10:00:10.000Z'
+            }),
+            createCheckpoint({
+                clientSessionId: 'session-2',
+                updatedAt: '2026-04-10T10:00:20.000Z'
+            })
+        ]);
+
+        await deletePlaybackCheckpoint('session-1');
+
+        expect(await getPlaybackCheckpoint('session-1')).toBeNull();
+        expect(await listPlaybackCheckpoints()).toEqual([
+            createCheckpoint({
+                clientSessionId: 'session-2',
+                updatedAt: '2026-04-10T10:00:20.000Z'
+            })
+        ]);
+    });
+});

--- a/server/src/client/src/modules/playback-checkpoint-store.ts
+++ b/server/src/client/src/modules/playback-checkpoint-store.ts
@@ -1,0 +1,127 @@
+import type { PlaybackSessionCheckpoint } from './playback-session';
+
+const PLAYBACK_CHECKPOINT_DATABASE_NAME = 'ocean-wave-playback';
+const PLAYBACK_CHECKPOINT_DATABASE_VERSION = 1;
+const PLAYBACK_CHECKPOINT_STORE_NAME = 'playback-checkpoints';
+
+const memoryCheckpointStore = new Map<string, PlaybackSessionCheckpoint>();
+
+const cloneCheckpoint = (checkpoint: PlaybackSessionCheckpoint) => {
+    return JSON.parse(JSON.stringify(checkpoint)) as PlaybackSessionCheckpoint;
+};
+
+const hasIndexedDb = () => {
+    return typeof indexedDB !== 'undefined';
+};
+
+const openPlaybackCheckpointDatabase = async () => {
+    return new Promise<IDBDatabase>((resolve, reject) => {
+        const request = indexedDB.open(
+            PLAYBACK_CHECKPOINT_DATABASE_NAME,
+            PLAYBACK_CHECKPOINT_DATABASE_VERSION
+        );
+
+        request.onupgradeneeded = () => {
+            const database = request.result;
+
+            if (!database.objectStoreNames.contains(PLAYBACK_CHECKPOINT_STORE_NAME)) {
+                database.createObjectStore(PLAYBACK_CHECKPOINT_STORE_NAME, { keyPath: 'clientSessionId' });
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(
+            request.error ?? new Error('Unable to open playback checkpoint database.')
+        );
+    });
+};
+
+const withPlaybackCheckpointStore = async <T>(
+    mode: IDBTransactionMode,
+    handler: (store: IDBObjectStore) => IDBRequest<T> | void
+) => {
+    const database = await openPlaybackCheckpointDatabase();
+
+    try {
+        return await new Promise<T | void>((resolve, reject) => {
+            const transaction = database.transaction(PLAYBACK_CHECKPOINT_STORE_NAME, mode);
+            const store = transaction.objectStore(PLAYBACK_CHECKPOINT_STORE_NAME);
+            const request = handler(store);
+
+            transaction.oncomplete = () => resolve(request?.result);
+            transaction.onerror = () => reject(
+                transaction.error ?? new Error('Playback checkpoint transaction failed.')
+            );
+
+            if (request) {
+                request.onerror = () => reject(
+                    request.error ?? new Error('Playback checkpoint request failed.')
+                );
+            }
+        });
+    } finally {
+        database.close();
+    }
+};
+
+export const savePlaybackCheckpoint = async (checkpoint: PlaybackSessionCheckpoint) => {
+    if (!hasIndexedDb()) {
+        memoryCheckpointStore.set(checkpoint.clientSessionId, cloneCheckpoint(checkpoint));
+        return;
+    }
+
+    await withPlaybackCheckpointStore('readwrite', (store) => store.put(checkpoint));
+};
+
+export const getPlaybackCheckpoint = async (clientSessionId: string) => {
+    if (!hasIndexedDb()) {
+        const checkpoint = memoryCheckpointStore.get(clientSessionId);
+
+        return checkpoint
+            ? cloneCheckpoint(checkpoint)
+            : null;
+    }
+
+    const checkpoint = await withPlaybackCheckpointStore<PlaybackSessionCheckpoint | undefined>(
+        'readonly',
+        (store) => store.get(clientSessionId)
+    );
+
+    return checkpoint
+        ? cloneCheckpoint(checkpoint)
+        : null;
+};
+
+export const listPlaybackCheckpoints = async () => {
+    if (!hasIndexedDb()) {
+        return Array.from(memoryCheckpointStore.values())
+            .map((checkpoint) => cloneCheckpoint(checkpoint))
+            .sort((left, right) => left.updatedAt.localeCompare(right.updatedAt));
+    }
+
+    const checkpoints = await withPlaybackCheckpointStore<PlaybackSessionCheckpoint[]>(
+        'readonly',
+        (store) => store.getAll()
+    );
+
+    return (checkpoints ?? [])
+        .map((checkpoint) => cloneCheckpoint(checkpoint))
+        .sort((left, right) => left.updatedAt.localeCompare(right.updatedAt));
+};
+
+export const deletePlaybackCheckpoint = async (clientSessionId: string) => {
+    if (!hasIndexedDb()) {
+        memoryCheckpointStore.delete(clientSessionId);
+        return;
+    }
+
+    await withPlaybackCheckpointStore('readwrite', (store) => store.delete(clientSessionId));
+};
+
+export const clearPlaybackCheckpoints = async () => {
+    if (!hasIndexedDb()) {
+        memoryCheckpointStore.clear();
+        return;
+    }
+
+    await withPlaybackCheckpointStore('readwrite', (store) => store.clear());
+};

--- a/server/src/client/src/modules/playback-session.test.ts
+++ b/server/src/client/src/modules/playback-session.test.ts
@@ -20,6 +20,7 @@ describe('PlaybackSessionTracker', () => {
         tracker.tick(5_300);
 
         expect(tracker.commit(5_500)).toEqual({
+            clientSessionId: expect.any(String),
             id: 'track-1',
             playedMs: 1_600,
             completionRate: expect.closeTo(0.008, 10),
@@ -44,6 +45,7 @@ describe('PlaybackSessionTracker', () => {
         tracker.tick(20_200);
 
         expect(tracker.commit(20_400)).toEqual({
+            clientSessionId: expect.any(String),
             id: 'track-2',
             playedMs: 700,
             completionRate: expect.closeTo(700 / 180_000, 10),
@@ -61,6 +63,7 @@ describe('PlaybackSessionTracker', () => {
         tracker.tick(2_000);
 
         expect(tracker.commit(2_500)).toEqual({
+            clientSessionId: expect.any(String),
             id: 'track-1',
             playedMs: 1_500,
             completionRate: expect.closeTo(0.0125, 10),
@@ -74,10 +77,84 @@ describe('PlaybackSessionTracker', () => {
         tracker.tick(5_600);
 
         expect(tracker.commit(5_800)).toEqual({
+            clientSessionId: expect.any(String),
             id: 'track-2',
             playedMs: 800,
             completionRate: expect.closeTo(800 / 60_000, 10),
             startedAt: new Date(5_000).toISOString()
+        });
+    });
+
+    it('creates overwriteable checkpoints with stable session identity across pause and resume', () => {
+        const tracker = new PlaybackSessionTracker();
+
+        tracker.play({
+            id: 'track-3',
+            durationMs: 90_000
+        }, 1_000);
+        tracker.tick(5_000);
+
+        const firstCheckpoint = tracker.createCheckpoint('queue-checkpoint', 11_000);
+
+        tracker.pause(11_500);
+        tracker.play({
+            id: 'track-3',
+            durationMs: 90_000
+        }, 20_000);
+        tracker.tick(23_000);
+        tracker.pause(23_000);
+
+        const secondCheckpoint = tracker.createCheckpoint('queue-pause', 23_000);
+
+        expect(firstCheckpoint).toEqual({
+            clientSessionId: expect.any(String),
+            trackId: 'track-3',
+            startedAt: new Date(1_000).toISOString(),
+            accumulatedPlayedMs: 10_000,
+            lastResumedAt: new Date(1_000).toISOString(),
+            active: true,
+            updatedAt: new Date(11_000).toISOString(),
+            source: 'queue-checkpoint'
+        });
+        expect(secondCheckpoint).toEqual({
+            clientSessionId: firstCheckpoint?.clientSessionId,
+            trackId: 'track-3',
+            startedAt: new Date(1_000).toISOString(),
+            accumulatedPlayedMs: 13_500,
+            lastResumedAt: new Date(20_000).toISOString(),
+            active: false,
+            updatedAt: new Date(23_000).toISOString(),
+            source: 'queue-pause'
+        });
+    });
+
+    it('starts a fresh client session id when the track changes', () => {
+        const tracker = new PlaybackSessionTracker();
+
+        tracker.play({
+            id: 'track-4',
+            durationMs: 100_000
+        }, 1_000);
+        tracker.tick(4_000);
+        const firstCheckpoint = tracker.createCheckpoint('queue-checkpoint', 4_000);
+
+        tracker.play({
+            id: 'track-5',
+            durationMs: 120_000
+        }, 10_000);
+        tracker.tick(12_000);
+        const secondCheckpoint = tracker.createCheckpoint('queue-checkpoint', 12_000);
+
+        expect(firstCheckpoint?.clientSessionId).not.toBe(secondCheckpoint?.clientSessionId);
+        expect(secondCheckpoint).toEqual({
+            clientSessionId: expect.any(String),
+            trackId: 'track-5',
+            startedAt: new Date(10_000).toISOString(),
+            accumulatedPlayedMs: 2_000,
+            lastResumedAt: new Date(10_000).toISOString(),
+            active: true,
+            updatedAt: new Date(12_000).toISOString(),
+            source: 'queue-checkpoint'
         });
     });
 });

--- a/server/src/client/src/modules/playback-session.ts
+++ b/server/src/client/src/modules/playback-session.ts
@@ -3,7 +3,19 @@ export interface PlaybackSessionTrack {
     durationMs: number;
 }
 
+export interface PlaybackSessionCheckpoint {
+    clientSessionId: string;
+    trackId: string;
+    startedAt: string;
+    accumulatedPlayedMs: number;
+    lastResumedAt: string | null;
+    active: boolean;
+    updatedAt: string;
+    source: string;
+}
+
 export interface PlaybackSessionCommit {
+    clientSessionId: string;
     id: string;
     playedMs: number;
     completionRate: number;
@@ -14,12 +26,22 @@ const normalizeDurationMs = (durationMs: number) => {
     return Math.max(Math.round(durationMs), 1);
 };
 
+const createPlaybackSessionId = () => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+        return crypto.randomUUID();
+    }
+
+    return `playback-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
 export class PlaybackSessionTracker {
+    private clientSessionId: string | null = null;
     private trackId: string | null = null;
     private durationMs = 0;
     private listenedMs = 0;
     private startedAtMs: number | null = null;
     private lastTickAtMs: number | null = null;
+    private lastResumedAtMs: number | null = null;
     private active = false;
 
     play(track: PlaybackSessionTrack, now = Date.now()) {
@@ -28,16 +50,12 @@ export class PlaybackSessionTracker {
         if (!this.active) {
             this.active = true;
             this.lastTickAtMs = now;
+            this.lastResumedAtMs = now;
         }
     }
 
     tick(now = Date.now()) {
-        if (!this.active || this.lastTickAtMs === null) {
-            return;
-        }
-
-        this.listenedMs += Math.max(now - this.lastTickAtMs, 0);
-        this.lastTickAtMs = now;
+        this.syncActiveListening(now);
     }
 
     pause(now = Date.now()) {
@@ -50,10 +68,47 @@ export class PlaybackSessionTracker {
         this.lastTickAtMs = null;
     }
 
+    getAccumulatedPlayedMs(now = Date.now()) {
+        if (!this.active || this.lastTickAtMs === null) {
+            return Math.max(Math.round(this.listenedMs), 0);
+        }
+
+        return Math.max(Math.round(
+            this.listenedMs + Math.max(now - this.lastTickAtMs, 0)
+        ), 0);
+    }
+
+    createCheckpoint(source: string, now = Date.now()): PlaybackSessionCheckpoint | null {
+        if (!this.clientSessionId || !this.trackId || this.startedAtMs === null) {
+            return null;
+        }
+
+        this.syncActiveListening(now);
+
+        const accumulatedPlayedMs = Math.max(Math.round(this.listenedMs), 0);
+
+        if (accumulatedPlayedMs <= 0) {
+            return null;
+        }
+
+        return {
+            clientSessionId: this.clientSessionId,
+            trackId: this.trackId,
+            startedAt: new Date(this.startedAtMs).toISOString(),
+            accumulatedPlayedMs,
+            lastResumedAt: this.lastResumedAtMs === null
+                ? null
+                : new Date(this.lastResumedAtMs).toISOString(),
+            active: this.active,
+            updatedAt: new Date(now).toISOString(),
+            source
+        };
+    }
+
     commit(now = Date.now()): PlaybackSessionCommit | null {
         this.pause(now);
 
-        if (!this.trackId || this.startedAtMs === null) {
+        if (!this.clientSessionId || !this.trackId || this.startedAtMs === null) {
             this.reset();
             return null;
         }
@@ -66,6 +121,7 @@ export class PlaybackSessionTracker {
         }
 
         const payload: PlaybackSessionCommit = {
+            clientSessionId: this.clientSessionId,
             id: this.trackId,
             playedMs,
             completionRate: Math.min(playedMs / normalizeDurationMs(this.durationMs), 1),
@@ -78,29 +134,46 @@ export class PlaybackSessionTracker {
     }
 
     reset() {
+        this.clientSessionId = null;
         this.trackId = null;
         this.durationMs = 0;
         this.listenedMs = 0;
         this.startedAtMs = null;
         this.lastTickAtMs = null;
+        this.lastResumedAtMs = null;
         this.active = false;
     }
 
     private ensureTrack(track: PlaybackSessionTrack, now: number) {
         if (this.trackId !== track.id) {
+            this.clientSessionId = createPlaybackSessionId();
             this.trackId = track.id;
             this.durationMs = normalizeDurationMs(track.durationMs);
             this.listenedMs = 0;
             this.startedAtMs = now;
             this.lastTickAtMs = null;
+            this.lastResumedAtMs = null;
             this.active = false;
             return;
         }
 
         this.durationMs = normalizeDurationMs(track.durationMs);
 
+        if (this.clientSessionId === null) {
+            this.clientSessionId = createPlaybackSessionId();
+        }
+
         if (this.startedAtMs === null) {
             this.startedAtMs = now;
         }
+    }
+
+    private syncActiveListening(now: number) {
+        if (!this.active || this.lastTickAtMs === null) {
+            return;
+        }
+
+        this.listenedMs += Math.max(now - this.lastTickAtMs, 0);
+        this.lastTickAtMs = now;
     }
 }

--- a/server/src/client/src/socket/music-listener.test.ts
+++ b/server/src/client/src/socket/music-listener.test.ts
@@ -1,0 +1,105 @@
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi
+} from 'vitest';
+
+const { emitMock } = vi.hoisted(() => ({ emitMock: vi.fn() }));
+
+vi.mock('./socket', () => ({
+    socket: {
+        connected: true,
+        on: vi.fn(),
+        off: vi.fn(),
+        emit: emitMock
+    }
+}));
+
+import {
+    clearPlaybackCheckpoints,
+    getPlaybackCheckpoint,
+    savePlaybackCheckpoint
+} from '~/modules/playback-checkpoint-store';
+import { socket } from './socket';
+import { MUSIC_COUNT, MusicListener } from './music-listener';
+
+const createCheckpoint = () => ({
+    clientSessionId: 'session-1',
+    trackId: 'track-1',
+    startedAt: '2026-04-10T10:00:00.000Z',
+    accumulatedPlayedMs: 12_000,
+    lastResumedAt: '2026-04-10T10:00:05.000Z',
+    active: false,
+    updatedAt: '2026-04-10T10:00:12.000Z',
+    source: 'queue-pagehide'
+});
+
+describe('MusicListener playback recovery', () => {
+    beforeEach(async () => {
+        await clearPlaybackCheckpoints();
+        MusicListener.pendingCountEvents = [];
+        MusicListener.isFlushing = false;
+        socket.connected = true;
+        emitMock.mockReset();
+    });
+
+    it('flushes pending count events and reports successful delivery after ack', async () => {
+        emitMock.mockImplementation((_event, _payload, ack) => {
+            ack?.({ ok: true });
+        });
+
+        const delivered = await MusicListener.count({
+            id: 'track-1',
+            clientSessionId: 'session-1',
+            playedMs: 15_000,
+            completionRate: 0.25,
+            startedAt: '2026-04-10T10:00:00.000Z',
+            source: 'queue-track-change'
+        });
+
+        expect(delivered).toBe(true);
+        expect(MusicListener.pendingCountEvents).toEqual([]);
+        expect(emitMock).toHaveBeenCalledWith(
+            MUSIC_COUNT,
+            expect.objectContaining({
+                id: 'track-1',
+                clientSessionId: 'session-1'
+            }),
+            expect.any(Function)
+        );
+    });
+
+    it('deletes recovered checkpoints after a successful recovery ack', async () => {
+        emitMock.mockImplementation((_event, _payload, ack) => {
+            ack?.({ ok: true });
+        });
+        await savePlaybackCheckpoint(createCheckpoint());
+
+        await MusicListener.recoverPlaybackCheckpoints();
+
+        expect(emitMock).toHaveBeenCalledWith(
+            MUSIC_COUNT,
+            expect.objectContaining({
+                id: 'track-1',
+                clientSessionId: 'session-1',
+                playedMs: 12_000,
+                source: 'queue-recovery'
+            }),
+            expect.any(Function)
+        );
+        expect(await getPlaybackCheckpoint('session-1')).toBeNull();
+    });
+
+    it('keeps checkpoints for the next startup when recovery delivery fails', async () => {
+        emitMock.mockImplementation((_event, _payload, ack) => {
+            ack?.({ ok: false });
+        });
+        await savePlaybackCheckpoint(createCheckpoint());
+
+        await MusicListener.recoverPlaybackCheckpoints();
+
+        expect(await getPlaybackCheckpoint('session-1')).toEqual(createCheckpoint());
+    });
+});

--- a/server/src/client/src/socket/music-listener.ts
+++ b/server/src/client/src/socket/music-listener.ts
@@ -1,16 +1,22 @@
 import { socket } from './socket';
 import type { Listener } from './listener';
+import {
+    deletePlaybackCheckpoint,
+    listPlaybackCheckpoints
+} from '~/modules/playback-checkpoint-store';
 
 export const MUSIC_LIKE = 'music-like';
 export const MUSIC_HATE = 'music-hate';
 export const MUSIC_COUNT = 'music-count';
+const MUSIC_COUNT_ACK_TIMEOUT_MS = 5_000;
 
 export interface CountPayload {
     id: string;
     playedMs: number;
-    completionRate: number;
+    completionRate?: number;
     startedAt: string;
     source?: string;
+    clientSessionId?: string;
 }
 
 interface Like {
@@ -75,10 +81,11 @@ export class MusicListener implements Listener {
         }
 
         if (!socket.connected || this.isFlushing) {
-            return;
+            return false;
         }
 
         this.isFlushing = true;
+        let deliveredPayload = payload === undefined;
 
         try {
             while (this.pendingCountEvents.length > 0) {
@@ -88,10 +95,43 @@ export class MusicListener implements Listener {
                     break;
                 }
 
-                socket.emit(MUSIC_COUNT, item);
+                const delivered = await this.emitCount(item);
+
+                if (!delivered) {
+                    this.pendingCountEvents.unshift(item);
+                    break;
+                }
+
+                if (item === payload) {
+                    deliveredPayload = true;
+                }
             }
         } finally {
             this.isFlushing = false;
+        }
+
+        return deliveredPayload;
+    }
+
+    static async recoverPlaybackCheckpoints() {
+        if (!socket.connected) {
+            return;
+        }
+
+        const checkpoints = await listPlaybackCheckpoints();
+
+        for (const checkpoint of checkpoints) {
+            const delivered = await this.emitCount({
+                id: checkpoint.trackId,
+                playedMs: checkpoint.accumulatedPlayedMs,
+                startedAt: checkpoint.startedAt,
+                source: 'queue-recovery',
+                clientSessionId: checkpoint.clientSessionId
+            });
+
+            if (delivered) {
+                await deletePlaybackCheckpoint(checkpoint.clientSessionId);
+            }
         }
     }
 
@@ -103,5 +143,22 @@ export class MusicListener implements Listener {
         socket.off(MUSIC_COUNT, this.handler.onCount);
 
         this.handler = null;
+    }
+
+    private static async emitCount(payload: CountPayload) {
+        if (!socket.connected) {
+            return false;
+        }
+
+        return new Promise<boolean>((resolve) => {
+            const timer = globalThis.setTimeout(() => {
+                resolve(false);
+            }, MUSIC_COUNT_ACK_TIMEOUT_MS);
+
+            socket.emit(MUSIC_COUNT, payload, (response?: { ok?: boolean }) => {
+                globalThis.clearTimeout(timer);
+                resolve(response?.ok !== false);
+            });
+        });
     }
 }

--- a/server/src/client/src/store/queue.ts
+++ b/server/src/client/src/store/queue.ts
@@ -19,8 +19,14 @@ import {
 import { toast } from '~/modules/toast';
 import { convertToMillisecond } from '~/modules/time';
 import { PlaybackSessionTracker } from '~/modules/playback-session';
+import {
+    deletePlaybackCheckpoint,
+    savePlaybackCheckpoint
+} from '~/modules/playback-checkpoint-store';
 import { MusicListener } from '~/socket';
 import { shuffle } from '~/modules/shuffle';
+
+const PLAYBACK_CHECKPOINT_INTERVAL_MS = 10_000;
 
 interface QueueStoreState {
     selected: number | null;
@@ -52,11 +58,15 @@ class QueueStore extends Store<QueueStoreState> {
     saveTimer: ReturnType<typeof setTimeout> | null = null;
     audioChannel: AudioChannel;
     playbackSessionTracker: PlaybackSessionTracker;
+    lastCheckpointClientSessionId: string | null = null;
+    lastCheckpointPlayedMs = 0;
 
     constructor() {
         super();
         this.saveTimer = null;
         this.playbackSessionTracker = new PlaybackSessionTracker();
+        this.lastCheckpointClientSessionId = null;
+        this.lastCheckpointPlayedMs = 0;
         this.state = {
             selected: null,
             currentTrackId: null,
@@ -91,11 +101,15 @@ class QueueStore extends Store<QueueStoreState> {
                 this.set({ isPlaying: true });
             },
             onPause: () => {
-                this.playbackSessionTracker.pause();
+                const now = Date.now();
+                this.playbackSessionTracker.pause(now);
+                void this.persistPlaybackCheckpoint('queue-pause', true, now).persisted;
                 this.set({ isPlaying: false });
             },
             onStop: () => {
-                this.playbackSessionTracker.pause();
+                const now = Date.now();
+                this.playbackSessionTracker.pause(now);
+                void this.persistPlaybackCheckpoint('queue-stop', true, now).persisted;
                 this.set({ isPlaying: false });
             },
             onEnded: () => {
@@ -134,7 +148,10 @@ class QueueStore extends Store<QueueStoreState> {
                     mix(20, () => undefined);
                 }
 
-                this.playbackSessionTracker.tick();
+                const now = Date.now();
+
+                this.playbackSessionTracker.tick(now);
+                void this.persistPlaybackCheckpoint('queue-checkpoint', false, now).persisted;
                 this.set({
                     currentTime: time,
                     progress
@@ -192,16 +209,26 @@ class QueueStore extends Store<QueueStoreState> {
             this.commitPlaybackEvent('queue-unload');
             this.audioChannel.stop();
         });
+        window.addEventListener('pagehide', () => {
+            void this.persistPlaybackCheckpoint('queue-pagehide', true).persisted;
+        });
+        document.addEventListener('visibilitychange', () => {
+            if (document.hidden) {
+                void this.persistPlaybackCheckpoint('queue-visibilitychange', true).persisted;
+            }
+        });
     }
 
     commitPlaybackEvent(source: string) {
-        const payload = this.playbackSessionTracker.commit();
+        const now = Date.now();
+        const { checkpoint, persisted } = this.persistPlaybackCheckpoint(source, true, now);
+        const payload = this.playbackSessionTracker.commit(now);
 
-        if (!payload) {
+        if (!payload || !checkpoint) {
             return;
         }
 
-        void MusicListener.count({
+        void this.flushCommittedPlaybackEvent(payload.clientSessionId, persisted, {
             ...payload,
             source
         });
@@ -479,6 +506,56 @@ class QueueStore extends Store<QueueStoreState> {
             }));
             this.saveTimer = null;
         }, 3000);
+    }
+
+    private persistPlaybackCheckpoint(source: string, force: boolean, now = Date.now()) {
+        const checkpoint = this.playbackSessionTracker.createCheckpoint(source, now);
+
+        if (!checkpoint) {
+            return {
+                checkpoint: null,
+                persisted: Promise.resolve()
+            };
+        }
+
+        if (this.lastCheckpointClientSessionId !== checkpoint.clientSessionId) {
+            this.lastCheckpointClientSessionId = checkpoint.clientSessionId;
+            this.lastCheckpointPlayedMs = 0;
+        }
+
+        const playedDelta = checkpoint.accumulatedPlayedMs - this.lastCheckpointPlayedMs;
+
+        if (!force && playedDelta < PLAYBACK_CHECKPOINT_INTERVAL_MS) {
+            return {
+                checkpoint,
+                persisted: Promise.resolve()
+            };
+        }
+
+        this.lastCheckpointClientSessionId = checkpoint.clientSessionId;
+        this.lastCheckpointPlayedMs = checkpoint.accumulatedPlayedMs;
+        const persisted = savePlaybackCheckpoint(checkpoint);
+
+        return {
+            checkpoint,
+            persisted
+        };
+    }
+
+    private async flushCommittedPlaybackEvent(
+        clientSessionId: string,
+        persisted: Promise<void>,
+        payload: Parameters<typeof MusicListener.count>[0]
+    ) {
+        await persisted;
+
+        const delivered = await MusicListener.count(payload);
+
+        if (!delivered) {
+            return;
+        }
+
+        await deletePlaybackCheckpoint(clientSessionId);
     }
 }
 

--- a/server/src/prisma/migrations/20260410121000_0006_playback_event_client_session_id/migration.sql
+++ b/server/src/prisma/migrations/20260410121000_0006_playback_event_client_session_id/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "PlaybackEvent" ADD COLUMN "clientSessionId" TEXT;
+
+CREATE UNIQUE INDEX "PlaybackEvent_clientSessionId_key" ON "PlaybackEvent"("clientSessionId");

--- a/server/src/prisma/schema.prisma
+++ b/server/src/prisma/schema.prisma
@@ -116,6 +116,7 @@ model PlaybackEvent {
     completionRate Float
     countedAsPlay  Boolean  @default(false)
     source         String
+    clientSessionId String? @unique
     connectorId    String?
     Music          Music    @relation(fields: [musicId], references: [id])
     musicId        Int

--- a/server/src/src/socket/music.test.ts
+++ b/server/src/src/socket/music.test.ts
@@ -126,4 +126,39 @@ describe('music playback counting', () => {
             countedAsPlay: false
         }));
     });
+
+    it('dedupes repeated recovery commits with the same clientSessionId', async () => {
+        const broadcastSpy = jest.spyOn(connectors, 'broadcast').mockResolvedValue([]);
+        const music = await createMusic({ duration: 180 });
+        const clientSessionId = 'session-dedupe-1';
+
+        await count({
+            id: music.id.toString(),
+            clientSessionId,
+            playedMs: 35_000,
+            completionRate: 35_000 / 180_000,
+            source: 'queue-recovery'
+        });
+        await count({
+            id: music.id.toString(),
+            clientSessionId,
+            playedMs: 35_000,
+            completionRate: 35_000 / 180_000,
+            source: 'queue-recovery'
+        });
+
+        const updatedMusic = await models.music.findUniqueOrThrow({ where: { id: music.id } });
+        const events = await models.playbackEvent.findMany({ where: { musicId: music.id } });
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            musicId: music.id,
+            clientSessionId,
+            playedMs: 35_000,
+            source: 'queue-recovery'
+        });
+        expect(updatedMusic.playCount).toBe(1);
+        expect(updatedMusic.totalPlayedMs).toBe(35_000);
+        expect(broadcastSpy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/server/src/src/socket/music.ts
+++ b/server/src/src/socket/music.ts
@@ -17,7 +17,17 @@ interface CountPayload {
     completionRate?: number;
     startedAt?: string;
     source?: string;
+    clientSessionId?: string;
     connectorId?: string | null;
+}
+
+interface CountResult {
+    id: string;
+    playCount: number;
+    lastPlayedAt: string | null;
+    totalPlayedMs: number;
+    countedAsPlay: boolean;
+    deduped: boolean;
 }
 
 const clamp = (value: number, min: number, max: number) => {
@@ -43,7 +53,17 @@ const shouldCountAsPlay = ({
 export const musicListener = (socket: Socket) => {
     socket.on(MUSIC_LIKE, like);
     socket.on(MUSIC_HATE, hate);
-    socket.on(MUSIC_COUNT, count);
+    socket.on(MUSIC_COUNT, async (
+        payload: CountPayload,
+        ack?: (response: { ok: boolean }) => void
+    ) => {
+        const result = await count({
+            ...payload,
+            connectorId: socket.id
+        });
+
+        ack?.({ ok: result !== null });
+    });
 };
 
 export const like = async ({ id = '' }) => {
@@ -106,15 +126,43 @@ export const count = async ({
     completionRate,
     startedAt,
     source = 'queue',
+    clientSessionId,
     connectorId = null
-}: CountPayload) => {
+}: CountPayload): Promise<CountResult | null> => {
     if (!id) {
-        return;
+        return null;
     }
 
     const $music = await models.music.findUnique({ where: { id: parseInt(id) } });
 
     if ($music) {
+        if (clientSessionId) {
+            const existingEvent = await models.playbackEvent.findUnique({
+                where: { clientSessionId },
+                include: {
+                    Music: {
+                        select: {
+                            id: true,
+                            playCount: true,
+                            lastPlayedAt: true,
+                            totalPlayedMs: true
+                        }
+                    }
+                }
+            });
+
+            if (existingEvent) {
+                return {
+                    id: existingEvent.Music.id.toString(),
+                    playCount: existingEvent.Music.playCount,
+                    lastPlayedAt: existingEvent.Music.lastPlayedAt?.toISOString() ?? null,
+                    totalPlayedMs: existingEvent.Music.totalPlayedMs,
+                    countedAsPlay: existingEvent.countedAsPlay,
+                    deduped: true
+                };
+            }
+        }
+
         const endedAt = new Date();
         const requestedStartedAt = startedAt ? new Date(startedAt) : null;
         const validStartedAtMs = requestedStartedAt && !Number.isNaN(requestedStartedAt.getTime())
@@ -133,7 +181,7 @@ export const count = async ({
         const normalizedPlayedMs = clamp(playedMs, 0, maxPlayedMs);
 
         if (normalizedPlayedMs <= 0) {
-            return;
+            return null;
         }
 
         const normalizedCompletionRate = clamp(
@@ -155,6 +203,7 @@ export const count = async ({
                     completionRate: normalizedCompletionRate,
                     countedAsPlay,
                     source,
+                    clientSessionId: clientSessionId ?? undefined,
                     connectorId: connectorId ?? undefined
                 }
             });
@@ -171,17 +220,25 @@ export const count = async ({
                 select: {
                     id: true,
                     playCount: true,
+                    lastPlayedAt: true,
                     totalPlayedMs: true
                 }
             });
         });
 
-        await connectors.broadcast(MUSIC_COUNT, {
+        const result = {
             id: updatedMusic.id.toString(),
             playCount: updatedMusic.playCount,
             lastPlayedAt: endedAt.toISOString(),
             totalPlayedMs: updatedMusic.totalPlayedMs,
-            countedAsPlay
-        });
+            countedAsPlay,
+            deduped: false
+        } satisfies CountResult;
+
+        await connectors.broadcast(MUSIC_COUNT, result);
+
+        return result;
     }
+
+    return null;
 };


### PR DESCRIPTION
## :dart: Goal
- Add local playback checkpoints so forced tab or app exits lose at most one checkpoint interval of listen time.
- Recover unfinished listen sessions on the next app launch without double-counting playback aggregates.

## :hammer_and_wrench: Core Changes
- Extended the client playback session tracker with `clientSessionId`, checkpoint snapshots, and stable active listening accumulation semantics.
- Added a checkpoint store module for saving, listing, overwriting, and deleting unfinished playback snapshots.
- Wired queue playback to save checkpoints every 10 seconds of active listening and immediately on `pause`, `pagehide`, `visibilitychange`, and final commit paths.
- Added startup recovery flush in the client socket layer and only delete checkpoints after server ack confirms the playback event was accepted.
- Added `PlaybackEvent.clientSessionId` with a migration and updated server counting so repeated recovery sends are deduped instead of incrementing `playCount` and `totalPlayedMs` again.
- Added focused client and server tests for checkpoint snapshots, checkpoint storage, recovery delivery, and server dedupe.

## :brain: Key Decisions
- Used `clientSessionId` as the single dedupe key across checkpoint recovery and final playback event commits.
- Kept checkpoints local-first and reused the existing final `PlaybackEvent` model instead of introducing server-side playback chunk append in this step.
- Forced checkpoint deletion to happen only after a successful socket ack so failed recovery attempts stay retryable on the next launch.

## :test_tube: Verification Guide
- `cd server/src/client && pnpm test`
  Expected: 13 test files and 45 tests pass.
- `cd server/src/client && pnpm lint`
  Expected: exits 0.
- `cd server/src/client && pnpm build`
  Expected: Vite production build succeeds.
- `cd server/src && pnpm test`
  Expected: 8 suites and 23 tests pass, including playback dedupe coverage.
- `cd server/src && pnpm build`
  Expected: TypeScript build succeeds.
- `cd server/src && pnpm lint`
  Expected: exits 0; existing `no-console` warnings remain but there are no lint errors.

## :white_check_mark: Checklist
- [x] Title follows `<emoji> <subject>`.
- [x] Local validation for the changed scope is complete.
- [x] Schema and migration changes are included in this PR.
- [x] Retry-safe recovery and server dedupe are both covered by tests.
- [x] Release-impacting changes are not included.
