### PR TITLE
🐛 Align auth with Ocean Brain policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,14 @@ Then open `http://localhost:44100`.
 
 ### Password Mode
 
-Ocean Wave runs in open mode by default. To require a shared password, set `OCEAN_WAVE_AUTH_PASSWORD`.
+Ocean Wave fails closed when auth mode is not configured. Use password mode for normal deployments.
 
-`OCEAN_WAVE_SESSION_SECRET` is recommended as a dedicated signing secret for the session cookie. If you omit it, Ocean Wave falls back to `OCEAN_WAVE_AUTH_PASSWORD`.
+Password mode requires both values:
+
+- `OCEAN_WAVE_AUTH_PASSWORD`: shared password for unlocking the app.
+- `OCEAN_WAVE_SESSION_SECRET`: dedicated signing secret for the session cookie.
+
+Ocean Wave does not fall back to the password as the session secret.
 
 Node.js:
 
@@ -81,3 +86,13 @@ docker run \
     -p 44100:44100 \
     baealex/ocean-wave
 ```
+
+### Explicit Open Mode
+
+Open mode is only allowed when you explicitly accept no-auth access:
+
+```bash
+OCEAN_WAVE_ALLOW_INSECURE_NO_AUTH=true npm start
+```
+
+Do not set `OCEAN_WAVE_ALLOW_INSECURE_NO_AUTH=true` together with `OCEAN_WAVE_AUTH_PASSWORD`.

--- a/server/src/cli/template/create-schema/__NAME__.spec.ts
+++ b/server/src/cli/template/create-schema/__NAME__.spec.ts
@@ -1,7 +1,14 @@
 import request from 'supertest';
 
-import app from '~/app';
+import { createApp } from '~/app';
+import { AUTH_SESSION_COOKIE_NAME } from '~/modules/auth-mode';
 import models from '~/models';
+
+const app = createApp({
+    mode: 'open',
+    source: 'explicit-open',
+    cookieName: AUTH_SESSION_COOKIE_NAME
+});
 
 beforeEach(async () => {
     await models.__NAME__.create({

--- a/server/src/client/src/api/index.ts
+++ b/server/src/client/src/api/index.ts
@@ -8,7 +8,7 @@ import type {
     SyncReportItem
 } from '~/models/type';
 
-export type AuthMode = 'open' | 'password-protected';
+export type AuthMode = 'open' | 'password';
 
 export interface AuthSession {
     mode: AuthMode;

--- a/server/src/package.json
+++ b/server/src/package.json
@@ -25,6 +25,7 @@
     },
     "homepage": "https://github.com/baealex/ocean-wave#readme",
     "dependencies": {
+        "@baejino/auth": "^0.1.1",
         "@prisma/client": "^5.22.0",
         "bcrypt": "^5.1.1",
         "express": "^4.22.1",

--- a/server/src/pnpm-lock.yaml
+++ b/server/src/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@baejino/auth':
+        specifier: ^0.1.1
+        version: 0.1.1
       '@prisma/client':
         specifier: ^5.22.0
         version: 5.22.0(prisma@5.22.0)
@@ -264,6 +267,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@baejino/auth@0.1.1':
+    resolution: {integrity: sha512-2Z3AcM3JFsL4DKYu/ajv0+6zL1D7q18axaBWfWRg6eK/JYE4p6oMUmt7k6RwwiqbB2bO0doyr0anmRQ22q+Gpg==}
 
   '@baejino/eslint-config@0.0.1':
     resolution: {integrity: sha512-MPDrQYORWBJxpdKfaAVJEoUdIZZn6n/XkTEmk8Oalxp6R+c6bJjKckb/WbLUndqAsw2x7OGafxS6a0Bk4USwIA==}
@@ -3176,6 +3182,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@baejino/auth@0.1.1': {}
 
   '@baejino/eslint-config@0.0.1(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:

--- a/server/src/src/app.ts
+++ b/server/src/src/app.ts
@@ -38,4 +38,4 @@ export const createApp = (authConfig: AuthConfig = resolveAuthConfig(process.env
         });
 };
 
-export default createApp();
+export default createApp;

--- a/server/src/src/modules/auth-mode.ts
+++ b/server/src/src/modules/auth-mode.ts
@@ -1,36 +1,33 @@
-export type AuthMode = 'open' | 'password-protected';
+import {
+    resolvePasswordAuthConfig,
+    type AuthConfig,
+    type AuthEnvironment
+} from '@baejino/auth';
 
-export interface AuthConfig {
-    mode: AuthMode;
-    password?: string;
-    sessionSecret?: string;
-}
+export type { AuthConfig, AuthMode } from '@baejino/auth';
 
-export interface AuthModeEnvironment {
+export const AUTH_SESSION_COOKIE_NAME = 'ocean-wave.sid';
+
+export interface AuthModeEnvironment extends AuthEnvironment {
     [key: string]: string | undefined;
     OCEAN_WAVE_AUTH_PASSWORD?: string;
     OCEAN_WAVE_SESSION_SECRET?: string;
+    OCEAN_WAVE_ALLOW_INSECURE_NO_AUTH?: string;
 }
 
-export const resolveAuthConfig = (env: AuthModeEnvironment): AuthConfig => {
-    const password = env.OCEAN_WAVE_AUTH_PASSWORD?.trim();
-
-    if (!password) {
-        return { mode: 'open' };
-    }
-
-    return {
-        mode: 'password-protected',
-        password,
-        sessionSecret: env.OCEAN_WAVE_SESSION_SECRET?.trim() || password
-    };
-};
+export const resolveAuthConfig = (env: AuthModeEnvironment): AuthConfig => resolvePasswordAuthConfig({
+    env,
+    passwordEnv: 'OCEAN_WAVE_AUTH_PASSWORD',
+    sessionSecretEnv: 'OCEAN_WAVE_SESSION_SECRET',
+    allowOpenEnv: 'OCEAN_WAVE_ALLOW_INSECURE_NO_AUTH',
+    cookieName: AUTH_SESSION_COOKIE_NAME
+});
 
 export const logAuthConfig = (authConfig: AuthConfig) => {
     if (authConfig.mode === 'open') {
-        process.stderr.write('[auth] Running in open mode. Authentication is not required.\n');
+        process.stderr.write('[auth] Running in explicit open mode. Authentication is not required.\n');
         return;
     }
 
-    process.stdout.write('[auth] Running in password-protected mode. Authentication is required.\n');
+    process.stdout.write('[auth] Running in password mode. Authentication is required.\n');
 };

--- a/server/src/src/modules/auth.test.ts
+++ b/server/src/src/modules/auth.test.ts
@@ -2,27 +2,49 @@ import {
     createAuthenticatedSessionValue,
     isAuthenticatedCookieHeader
 } from '~/modules/auth';
-import { resolveAuthConfig } from '~/modules/auth-mode';
+import { AUTH_SESSION_COOKIE_NAME, resolveAuthConfig, type AuthConfig } from '~/modules/auth-mode';
+
+const openAuthConfig: AuthConfig = {
+    mode: 'open',
+    source: 'explicit-open',
+    cookieName: AUTH_SESSION_COOKIE_NAME
+};
 
 describe('auth helpers', () => {
-    it('resolves open mode when no password is configured', () => {
-        expect(resolveAuthConfig({})).toEqual({ mode: 'open' });
+    it('fails closed when neither password nor explicit open mode is configured', () => {
+        expect(() => resolveAuthConfig({})).toThrow('Unable to resolve auth mode');
     });
 
-    it('accepts only signed session cookies in password-protected mode', () => {
+    it('resolves explicit open mode only when insecure no-auth is allowed', () => {
+        expect(resolveAuthConfig({ OCEAN_WAVE_ALLOW_INSECURE_NO_AUTH: 'true' })).toEqual(openAuthConfig);
+    });
+
+    it('requires a dedicated session secret in password mode', () => {
+        expect(() => resolveAuthConfig({ OCEAN_WAVE_AUTH_PASSWORD: 'secret' })).toThrow('Missing OCEAN_WAVE_SESSION_SECRET');
+    });
+
+    it('fails closed when password mode and open mode are both configured', () => {
+        expect(() => resolveAuthConfig({
+            OCEAN_WAVE_AUTH_PASSWORD: 'secret',
+            OCEAN_WAVE_SESSION_SECRET: 'session-secret',
+            OCEAN_WAVE_ALLOW_INSECURE_NO_AUTH: 'true'
+        })).toThrow('Conflicting auth config');
+    });
+
+    it('accepts only signed session cookies in password mode', () => {
         const authConfig = resolveAuthConfig({
             OCEAN_WAVE_AUTH_PASSWORD: 'secret',
             OCEAN_WAVE_SESSION_SECRET: 'session-secret'
         });
 
-        const sessionCookie = `ocean-wave.sid=${createAuthenticatedSessionValue(authConfig)}`;
+        const sessionCookie = `${AUTH_SESSION_COOKIE_NAME}=${createAuthenticatedSessionValue(authConfig)}`;
 
         expect(isAuthenticatedCookieHeader(authConfig, sessionCookie)).toBe(true);
-        expect(isAuthenticatedCookieHeader(authConfig, 'ocean-wave.sid=tampered')).toBe(false);
+        expect(isAuthenticatedCookieHeader(authConfig, `${AUTH_SESSION_COOKIE_NAME}=tampered`)).toBe(false);
         expect(isAuthenticatedCookieHeader(authConfig, undefined)).toBe(false);
     });
 
     it('treats open mode as always authenticated for request guards', () => {
-        expect(isAuthenticatedCookieHeader({ mode: 'open' }, undefined)).toBe(true);
+        expect(isAuthenticatedCookieHeader(openAuthConfig, undefined)).toBe(true);
     });
 });

--- a/server/src/src/modules/auth.ts
+++ b/server/src/src/modules/auth.ts
@@ -1,85 +1,30 @@
-import crypto from 'crypto';
 import type { Request, Response, RequestHandler } from 'express';
 import type { Socket } from 'socket.io';
+import {
+    buildAuthSessionResponse,
+    buildUnauthorizedGraphqlPayload,
+    buildUnauthorizedPayload
+} from '@baejino/auth';
+import { parseCookieHeader } from '@baejino/auth/cookies';
+import {
+    compareSharedSecret,
+    createAuthenticatedSessionValue as createCommonAuthenticatedSessionValue,
+    verifyAuthenticatedSessionValue
+} from '@baejino/auth/crypto';
 
-import type { AuthConfig, AuthMode } from './auth-mode';
+import type { AuthConfig } from './auth-mode';
 
-export interface AuthSessionResponse {
-    mode: AuthMode;
-    authRequired: boolean;
-    authenticated: boolean;
-}
+export type { AuthSessionResponse } from '@baejino/auth';
+export { buildAuthSessionResponse, compareSharedSecret };
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
-const SESSION_COOKIE_NAME = 'ocean-wave.sid';
-const AUTHENTICATED_SESSION_VALUE = 'authenticated';
-
-const UNAUTHORIZED_PAYLOAD = {
-    code: 'UNAUTHORIZED',
-    message: 'Authentication required'
-} as const;
-
-const UNAUTHORIZED_GRAPHQL_PAYLOAD = {
-    errors: [{
-        message: 'Authentication required',
-        extensions: { code: 'UNAUTHORIZED' }
-    }]
-} as const;
-
-const normalizeCookieHeader = (cookieHeader?: string | string[]) => {
-    if (!cookieHeader) {
-        return '';
-    }
-
-    return Array.isArray(cookieHeader)
-        ? cookieHeader.join(';')
-        : cookieHeader;
-};
-
-const parseCookieHeader = (cookieHeader?: string | string[]) => {
-    const normalizedCookieHeader = normalizeCookieHeader(cookieHeader);
-
-    return normalizedCookieHeader
-        .split(';')
-        .map((segment) => segment.trim())
-        .filter(Boolean)
-        .reduce<Record<string, string>>((cookies, segment) => {
-        const separatorIndex = segment.indexOf('=');
-
-        if (separatorIndex === -1) {
-            return cookies;
-        }
-
-        const key = decodeURIComponent(segment.slice(0, separatorIndex).trim());
-        const value = decodeURIComponent(segment.slice(separatorIndex + 1).trim());
-
-        cookies[key] = value;
-        return cookies;
-    }, {});
-};
-
-const getSigningSecret = (authConfig: AuthConfig) => authConfig.sessionSecret || authConfig.password || '';
-
-const signSessionValue = (value: string, authConfig: AuthConfig) => {
-    return crypto
-        .createHmac('sha256', getSigningSecret(authConfig))
-        .update(value)
-        .digest('base64url');
-};
-
-export const compareSharedSecret = (expected: string, actual: string) => {
-    const expectedBuffer = Buffer.from(expected, 'utf8');
-    const actualBuffer = Buffer.from(actual, 'utf8');
-
-    if (expectedBuffer.length !== actualBuffer.length) {
-        return false;
-    }
-
-    return crypto.timingSafeEqual(expectedBuffer, actualBuffer);
-};
 
 export const createAuthenticatedSessionValue = (authConfig: AuthConfig) => {
-    return `${AUTHENTICATED_SESSION_VALUE}.${signSessionValue(AUTHENTICATED_SESSION_VALUE, authConfig)}`;
+    if (authConfig.mode !== 'password') {
+        throw new Error('Authenticated session can only be created in password auth mode.');
+    }
+
+    return createCommonAuthenticatedSessionValue(authConfig);
 };
 
 export const isAuthenticatedCookieHeader = (
@@ -90,43 +35,17 @@ export const isAuthenticatedCookieHeader = (
         return true;
     }
 
-    const sessionCookie = parseCookieHeader(cookieHeader)[SESSION_COOKIE_NAME];
+    const sessionCookie = parseCookieHeader(cookieHeader ?? null)[authConfig.cookieName];
 
     if (!sessionCookie) {
         return false;
     }
 
-    const separatorIndex = sessionCookie.indexOf('.');
-
-    if (separatorIndex === -1) {
-        return false;
-    }
-
-    const value = sessionCookie.slice(0, separatorIndex);
-    const signature = sessionCookie.slice(separatorIndex + 1);
-
-    if (value !== AUTHENTICATED_SESSION_VALUE || !signature) {
-        return false;
-    }
-
-    return compareSharedSecret(signSessionValue(value, authConfig), signature);
+    return verifyAuthenticatedSessionValue(sessionCookie, authConfig);
 };
 
 export const isAuthenticatedRequest = (authConfig: AuthConfig, req: Request) => {
     return isAuthenticatedCookieHeader(authConfig, req.headers.cookie);
-};
-
-export const buildAuthSessionResponse = (
-    authConfig: AuthConfig,
-    authenticated: boolean
-): AuthSessionResponse => {
-    return {
-        mode: authConfig.mode,
-        authRequired: authConfig.mode === 'password-protected',
-        authenticated: authConfig.mode === 'password-protected'
-            ? authenticated
-            : false
-    };
 };
 
 export const resolveAuthSessionResponse = (
@@ -137,7 +56,7 @@ export const resolveAuthSessionResponse = (
 };
 
 export const setAuthenticatedSession = (authConfig: AuthConfig, res: Response) => {
-    res.cookie(SESSION_COOKIE_NAME, createAuthenticatedSessionValue(authConfig), {
+    res.cookie(authConfig.cookieName, createAuthenticatedSessionValue(authConfig), {
         httpOnly: true,
         sameSite: 'lax',
         secure: process.env.NODE_ENV === 'production',
@@ -145,8 +64,8 @@ export const setAuthenticatedSession = (authConfig: AuthConfig, res: Response) =
     });
 };
 
-export const clearAuthenticatedSession = (res: Response) => {
-    res.clearCookie(SESSION_COOKIE_NAME, {
+export const clearAuthenticatedSession = (authConfig: AuthConfig, res: Response) => {
+    res.clearCookie(authConfig.cookieName, {
         httpOnly: true,
         sameSite: 'lax',
         secure: process.env.NODE_ENV === 'production',
@@ -161,7 +80,7 @@ export const requireAuthenticatedRequest = (authConfig: AuthConfig): RequestHand
             return;
         }
 
-        res.status(401).set(JSON_HEADERS).json(UNAUTHORIZED_PAYLOAD).end();
+        res.status(401).set(JSON_HEADERS).json(buildUnauthorizedPayload()).end();
     };
 };
 
@@ -172,7 +91,7 @@ export const requireAuthenticatedGraphqlRequest = (authConfig: AuthConfig): Requ
             return;
         }
 
-        res.status(401).set(JSON_HEADERS).json(UNAUTHORIZED_GRAPHQL_PAYLOAD).end();
+        res.status(401).set(JSON_HEADERS).json(buildUnauthorizedGraphqlPayload()).end();
     };
 };
 

--- a/server/src/src/views/auth.test.ts
+++ b/server/src/src/views/auth.test.ts
@@ -1,10 +1,25 @@
 import request from 'supertest';
 
 import { createApp } from '~/app';
+import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '~/modules/auth-mode';
+
+const openAuthConfig: AuthConfig = {
+    mode: 'open',
+    source: 'explicit-open',
+    cookieName: AUTH_SESSION_COOKIE_NAME
+};
+
+const passwordAuthConfig: AuthConfig = {
+    mode: 'password',
+    source: 'password',
+    cookieName: AUTH_SESSION_COOKIE_NAME,
+    password: 'secret',
+    sessionSecret: 'session-secret'
+};
 
 describe('auth http flow', () => {
-    it('keeps existing open-mode behavior when no password is configured', async () => {
-        const app = createApp({ mode: 'open' });
+    it('keeps explicit open-mode behavior when no-auth is allowed', async () => {
+        const app = createApp(openAuthConfig);
 
         const session = await request(app).get('/api/auth/session');
         expect(session.status).toBe(200);
@@ -34,18 +49,14 @@ describe('auth http flow', () => {
     });
 
     it('protects api and graphql in password mode until login, then clears access on logout', async () => {
-        const app = createApp({
-            mode: 'password-protected',
-            password: 'secret',
-            sessionSecret: 'session-secret'
-        });
+        const app = createApp(passwordAuthConfig);
 
         const agent = request.agent(app);
 
         const anonymousSession = await agent.get('/api/auth/session');
         expect(anonymousSession.status).toBe(200);
         expect(anonymousSession.body).toEqual({
-            mode: 'password-protected',
+            mode: 'password',
             authRequired: true,
             authenticated: false
         });
@@ -74,7 +85,7 @@ describe('auth http flow', () => {
 
         expect(login.status).toBe(200);
         expect(login.body).toEqual({
-            mode: 'password-protected',
+            mode: 'password',
             authRequired: true,
             authenticated: true
         });
@@ -82,7 +93,7 @@ describe('auth http flow', () => {
         const authenticatedSession = await agent.get('/api/auth/session');
         expect(authenticatedSession.status).toBe(200);
         expect(authenticatedSession.body).toEqual({
-            mode: 'password-protected',
+            mode: 'password',
             authRequired: true,
             authenticated: true
         });
@@ -104,7 +115,7 @@ describe('auth http flow', () => {
 
         expect(logout.status).toBe(200);
         expect(logout.body).toEqual({
-            mode: 'password-protected',
+            mode: 'password',
             authRequired: true,
             authenticated: false
         });

--- a/server/src/src/views/auth.ts
+++ b/server/src/src/views/auth.ts
@@ -27,7 +27,7 @@ export const createSessionStatusHandler = (authConfig: AuthConfig): Controller =
 
 export const createLoginHandler = (authConfig: AuthConfig): Controller => {
     return async (req, res) => {
-        if (authConfig.mode !== 'password-protected' || !authConfig.password) {
+        if (authConfig.mode !== 'password') {
             res.status(409).json(AUTH_DISABLED_RESPONSE).end();
             return;
         }
@@ -48,7 +48,7 @@ export const createLoginHandler = (authConfig: AuthConfig): Controller => {
 
 export const createLogoutHandler = (authConfig: AuthConfig): Controller => {
     return async (_req, res) => {
-        clearAuthenticatedSession(res);
+        clearAuthenticatedSession(authConfig, res);
         res.status(200).json(buildAuthSessionResponse(authConfig, false)).end();
     };
 };

--- a/server/src/src/views/cache/cache.test.ts
+++ b/server/src/src/views/cache/cache.test.ts
@@ -6,6 +6,7 @@ import request from 'supertest';
 
 import models from '~/models';
 import { createApp } from '~/app';
+import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '~/modules/auth-mode';
 import { resolveCachePath } from '~/modules/storage-paths';
 
 jest.mock('music-metadata', () => ({ parseBuffer: jest.fn() }));
@@ -20,6 +21,11 @@ jest.mock('sharp', () => {
 });
 
 const parseBufferMock = jest.mocked(parseBuffer);
+const openAuthConfig: AuthConfig = {
+    mode: 'open',
+    source: 'explicit-open',
+    cookieName: AUTH_SESSION_COOKIE_NAME
+};
 
 const createTempTrackFile = ({
     directory,
@@ -135,7 +141,7 @@ describe('GET /cache/resized/:albumId.jpg', () => {
             }
         });
 
-        const app = createApp({ mode: 'open' });
+        const app = createApp(openAuthConfig);
         const response = await request(app).get(`/cache/resized/${album.id}.jpg`);
 
         expect(response.status).toBe(200);

--- a/server/src/src/views/home/home.test.ts
+++ b/server/src/src/views/home/home.test.ts
@@ -1,10 +1,17 @@
 import request from 'supertest';
 
 import { createApp } from '~/app';
+import { AUTH_SESSION_COOKIE_NAME, type AuthConfig } from '~/modules/auth-mode';
+
+const openAuthConfig: AuthConfig = {
+    mode: 'open',
+    source: 'explicit-open',
+    cookieName: AUTH_SESSION_COOKIE_NAME
+};
 
 describe('GET /home', () => {
     it('return text Hello, My Express JS!', async () => {
-        const app = createApp({ mode: 'open' });
+        const app = createApp(openAuthConfig);
         const res = await request(app).get('/api/home');
         expect(res.text).toContain('Hello, My Express JS!');
     });


### PR DESCRIPTION
## :dart: Goal

Align Ocean Wave single-session auth with the Ocean Brain fail-closed policy.

## :hammer_and_wrench: Core Changes

- Add `@baejino/auth@^0.1.1` to the server and use its common auth helpers.
- Require either password mode or explicit open mode.
- Require `OCEAN_WAVE_SESSION_SECRET` when `OCEAN_WAVE_AUTH_PASSWORD` is set.
- Replace the `password-protected` session mode with the shared `password` mode.
- Keep Express and Socket.IO integration inside Ocean Wave while sharing only framework-independent auth logic.
- Update auth tests, app factory usage, and README auth setup docs.

## :brain: Key Decisions

- Do not auto-open the app when `OCEAN_WAVE_AUTH_PASSWORD` is missing.
- Do not fall back to the password as the session signing secret.
- Allow no-auth access only through `OCEAN_WAVE_ALLOW_INSECURE_NO_AUTH=true`.
- Keep app-specific framework adapters out of `@baejino/auth`.

## :test_tube: Verification Guide

Expected result for each command: pass.

- `npm run test:metadata`
- `pnpm lint` in `server/src`
- `pnpm test` in `server/src`
- `pnpm build` in `server/src`
- `pnpm lint` in `server/src/client`
- `pnpm build` in `server/src/client`

Runtime smoke was also checked:

- no auth env fails closed
- explicit open mode responds on `/api/auth/session`, `/api/home`, and `/`
- password mode blocks anonymous access and allows access after login

## :white_check_mark: Checklist

- [x] Local validation for the changed scope is complete.
- [x] Auth env and README changes are documented.
- [x] PR title follows `<emoji> <subject>` and starts with an English verb.
- [x] Verification guide contains concrete commands and expected results.
