### PR TITLE
✨ Align mobile page headers

### DIFF
--- a/server/src/client/src/components/shared/SiteHeader/SiteHeader.module.scss
+++ b/server/src/client/src/components/shared/SiteHeader/SiteHeader.module.scss
@@ -5,13 +5,16 @@
     display: flex;
     flex-direction: column;
     gap: var.$SPACING_SM;
-    padding: 0.75rem;
+    justify-content: center;
+    height: var.$APP_HEADER_HEIGHT_MOBILE;
+    padding: 0 var.$APP_HEADER_PADDING_INLINE_MOBILE;
     background: var.$COLOR_BACKGROUND;
     border-bottom: 1px solid var.$COLOR_BORDER_SUBTLE;
 
     @media (min-width: 1024px) {
         height: 100%;
         gap: var.$SPACING_MD;
+        justify-content: flex-start;
         padding: var.$SPACING_LG 0.75rem;
         border-right: 1px solid var.$COLOR_BORDER_SUBTLE;
         border-bottom: none;

--- a/server/src/client/src/components/shared/SubPageHeader/SubPageHeader.module.scss
+++ b/server/src/client/src/components/shared/SubPageHeader/SubPageHeader.module.scss
@@ -4,25 +4,40 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0 var.$SPACING_MD;
-    height: 56px;
+    height: var.$APP_HEADER_HEIGHT_MOBILE;
+    padding: 0 var.$APP_HEADER_PADDING_INLINE_MOBILE;
     background: var.$COLOR_BACKGROUND;
     border-bottom: 1px solid var.$COLOR_BORDER_SUBTLE;
 
     @media (min-width: 1024px) {
         height: 100%;
+        padding: 0 var.$SPACING_MD;
         border-bottom: none;
         border-right: 1px solid var.$COLOR_BORDER_SUBTLE;
     }
 
     button {
+        width: var.$CONTROL_HEIGHT_SM;
+        height: var.$CONTROL_HEIGHT_SM;
         background-color: transparent;
         border: none;
+        border-radius: var.$RADIUS_FULL;
         color: inherit;
         cursor: pointer;
         display: flex;
         align-items: center;
         justify-content: center;
+
+        &:focus-visible {
+            outline: 2px solid var.$COLOR_FOCUS;
+            outline-offset: 2px;
+        }
+
+        @media (min-width: 1024px) {
+            width: auto;
+            height: auto;
+            min-height: var.$CONTROL_HEIGHT_SM;
+        }
 
         .back-text {
             display: none;

--- a/server/src/client/src/pages/Player.module.scss
+++ b/server/src/client/src/pages/Player.module.scss
@@ -42,15 +42,17 @@
     }
 
     .top-bar {
-        width: min(100%, 30rem);
-        margin: 0 auto 0.875rem;
+        width: 100%;
+        min-width: 0;
+        flex-shrink: 0;
+        margin: 0 0 0.875rem;
         display: flex;
         align-items: center;
     }
 
     .utility-button {
-        width: 2.25rem;
-        height: 2.25rem;
+        width: var.$CONTROL_HEIGHT_MD;
+        height: var.$CONTROL_HEIGHT_MD;
         border: none;
         border-radius: var.$RADIUS_FULL;
         background: transparent;
@@ -62,8 +64,13 @@
         transition-property: color, background-color;
 
         svg {
-            width: 1rem;
-            height: 1rem;
+            width: 1.125rem;
+            height: 1.125rem;
+        }
+
+        &:focus-visible {
+            outline: 2px solid var.$COLOR_FOCUS;
+            outline-offset: 2px;
         }
 
         @include var.hover-capable {
@@ -358,6 +365,32 @@
 
         &.empty-button-primary {
             color: var.$COLOR_TEXT;
+        }
+    }
+
+    @media (max-width: 1023px) {
+        .container {
+            padding-top: 0;
+        }
+
+        .top-bar {
+            width: auto;
+            height: var.$APP_HEADER_HEIGHT_MOBILE;
+            margin: 0 -1rem 0.875rem;
+            padding: 0 var.$APP_HEADER_PADDING_INLINE_MOBILE;
+            background: var.$COLOR_BACKGROUND;
+            border-bottom: 1px solid var.$COLOR_BORDER_SUBTLE;
+        }
+
+        .utility-button {
+            width: var.$CONTROL_HEIGHT_SM;
+            height: var.$CONTROL_HEIGHT_SM;
+            color: inherit;
+
+            svg {
+                width: 1.25rem;
+                height: 1.25rem;
+            }
         }
     }
 

--- a/server/src/client/src/pages/Queue.module.scss
+++ b/server/src/client/src/pages/Queue.module.scss
@@ -4,14 +4,17 @@
     width: 100%;
     height: 100%;
     min-height: 100%;
+    display: flex;
+    flex-direction: column;
     overflow-y: auto;
     overflow-x: hidden;
     background: var.$GRADIENT_PAGE;
 }
 
 .container {
+    flex: 1;
     width: min(100%, 38rem);
-    min-height: 100%;
+    min-height: 0;
     margin: 0 auto;
     padding: 0 1rem calc(1.5rem + env(safe-area-inset-bottom));
     display: flex;
@@ -23,13 +26,20 @@
     position: sticky;
     top: 0;
     z-index: 3;
+    flex-shrink: 0;
+    width: 100%;
+    padding: calc(env(safe-area-inset-top) + 0.875rem) 1rem 0.875rem;
+    background: var.$GRADIENT_STICKY;
+    backdrop-filter: blur(10px);
+}
+
+.top-bar-inner {
+    width: 100%;
+    min-width: 0;
     display: grid;
     grid-template-columns: var.$CONTROL_HEIGHT_MD minmax(0, 1fr) auto;
     align-items: center;
     gap: 0.75rem;
-    padding: calc(env(safe-area-inset-top) + 0.875rem) 0 0.875rem;
-    background: var.$GRADIENT_STICKY;
-    backdrop-filter: blur(10px);
 }
 
 .utility-button {
@@ -77,6 +87,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.page-title-selection {
+    display: none;
 }
 
 .top-bar-spacer {
@@ -367,6 +381,74 @@
     justify-content: center;
 }
 
+@media (max-width: 1023px) {
+    .top-bar {
+        height: var.$APP_HEADER_HEIGHT_MOBILE;
+        padding: 0 var.$APP_HEADER_PADDING_INLINE_MOBILE;
+        background: var.$COLOR_BACKGROUND;
+        border-bottom: 1px solid var.$COLOR_BORDER_SUBTLE;
+        backdrop-filter: none;
+    }
+
+    .top-bar-inner {
+        height: 100%;
+        grid-template-columns: var.$CONTROL_HEIGHT_SM minmax(0, 1fr) auto;
+        gap: 0.5rem;
+    }
+
+    .utility-button {
+        width: var.$CONTROL_HEIGHT_SM;
+        height: var.$CONTROL_HEIGHT_SM;
+        color: inherit;
+
+        svg {
+            width: 1.25rem;
+            height: 1.25rem;
+        }
+    }
+
+    .page-copy {
+        justify-content: center;
+        gap: 0;
+    }
+
+    .page-title {
+        font-size: 0.9375rem;
+        line-height: 1.2;
+    }
+
+    .page-title-selecting {
+        .page-title-default {
+            display: none;
+        }
+
+        .page-title-selection {
+            display: inline;
+        }
+    }
+
+    .page-summary {
+        display: none;
+    }
+
+    .top-bar-spacer {
+        width: var.$CONTROL_HEIGHT_SM;
+        height: var.$CONTROL_HEIGHT_SM;
+    }
+
+    .top-bar-actions {
+        gap: 0.375rem;
+    }
+
+    .edit-button,
+    .summary-action {
+        min-height: 2.25rem;
+        padding: 0.5rem 0.75rem;
+        font-size: 0.8125rem;
+        white-space: nowrap;
+    }
+}
+
 @media (max-width: 640px) {
     .container {
         padding-inline: 0.875rem;
@@ -392,11 +474,7 @@
     }
 
     .top-bar {
-        gap: 0.625rem;
-    }
-
-    .top-bar-actions {
-        gap: 0.375rem;
+        padding-inline: var.$APP_HEADER_PADDING_INLINE_MOBILE;
     }
 
     .section-label {

--- a/server/src/client/src/pages/Queue.tsx
+++ b/server/src/client/src/pages/Queue.tsx
@@ -486,8 +486,8 @@ export default function Queue() {
 
     return (
         <div className={cx('Queue')} ref={scrollRef}>
-            <div className={cx('container')}>
-                <div className={cx('top-bar')}>
+            <div className={cx('top-bar')}>
+                <div className={cx('top-bar-inner')}>
                     <button
                         type="button"
                         className={cx('utility-button')}
@@ -497,8 +497,17 @@ export default function Queue() {
                     </button>
 
                     <div className={cx('page-copy')}>
-                        <Text as="h1" size="title" weight="semibold" className={cx('page-title')}>
-                            Queue
+                        <Text
+                            as="h1"
+                            size="title"
+                            weight="semibold"
+                            className={cx('page-title', { 'page-title-selecting': isSelectMode })}>
+                            {isSelectMode && (
+                                <span className={cx('page-title-selection')}>
+                                    {selectedItems.length} selected
+                                </span>
+                            )}
+                            <span className={cx('page-title-default')}>Queue</span>
                         </Text>
                         <Text as="p" variant="muted" size="xs" className={cx('page-summary')}>
                             {isSelectMode
@@ -538,7 +547,9 @@ export default function Queue() {
                         <div className={cx('top-bar-spacer')} />
                     )}
                 </div>
+            </div>
 
+            <div className={cx('container')}>
                 {items.length > 0 ? (
                     <>
                         <div className={cx('list-shell')} ref={listRef}>

--- a/server/src/client/src/styles/var.scss
+++ b/server/src/client/src/styles/var.scss
@@ -60,6 +60,8 @@ $SHADOW_SUB: var(--b-card-shadow-sub);
 $APP_SHELL_BACKGROUND: var(--b-app-shell-background);
 $APP_SHELL_BORDER: var(--b-app-shell-border);
 $APP_SHELL_SHADOW: var(--b-app-shell-shadow);
+$APP_HEADER_HEIGHT_MOBILE: 4rem;
+$APP_HEADER_PADDING_INLINE_MOBILE: 0.75rem;
 
 /* GRADIENTS */
 $GRADIENT_PRIMARY: var(--b-gradient-primary);


### PR DESCRIPTION
## :dart: Goal

Align the mobile page header surfaces so the side header, sub-page header, player header, and queue header use a consistent height and spacing.

## :hammer_and_wrench: Core Changes

- Add shared mobile header size tokens in `var.scss`.
- Align `SiteHeader` and `SubPageHeader` mobile height and inline padding.
- Update the player top bar to use the same mobile header treatment.
- Move the queue top bar outside the scroll container so it behaves as a consistent page header.
- Show the selected item count in the queue title area on mobile selection mode.
- Add focus-visible treatment to header utility buttons.

## :brain: Key Decisions

- Keep the desktop layout behavior intact and scope the new header treatment to mobile breakpoints.
- Centralize mobile header height and padding tokens instead of repeating hardcoded values.
- Preserve the queue summary/actions on larger screens while simplifying the mobile selection title.

## :test_tube: Verification Guide

Expected result for each command: pass.

- `pnpm lint` in `server/src/client`
- `pnpm test` in `server/src/client`
- `pnpm build` in `server/src/client`

Runtime smoke was also checked against the local server at `http://localhost:44100`:

- `/api/auth/session` returns open-mode session JSON
- `/` returns the Ocean Wave app shell
- `/queue` returns the Ocean Wave app shell

## :white_check_mark: Checklist

- [x] Local validation for the changed scope is complete.
- [x] UI token and layout changes are scoped to the client.
- [x] PR title follows `<emoji> <subject>` and starts with an English verb.
- [x] Verification guide contains concrete commands and expected results.
