### PR TITLE
♻️ Standardize GraphQL query contracts

### DIFF
--- a/server/src/client/src/api/index.test.ts
+++ b/server/src/client/src/api/index.test.ts
@@ -1,0 +1,48 @@
+import axios from 'axios';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getArtist, graphQLRequest } from './index';
+
+interface GraphqlPayload {
+    operationName?: string;
+    query: string;
+    variables?: Record<string, unknown>;
+}
+
+describe('GraphQL API requests', () => {
+    it('sends variables through the GraphQL request body', async () => {
+        const request = vi.spyOn(axios, 'request').mockResolvedValue({
+            data: { data: { artist: { id: '7' } } }
+        });
+
+        await getArtist('7');
+
+        const payload = request.mock.calls[0]?.[0]?.data as GraphqlPayload;
+
+        expect(payload.operationName).toBe('Artist');
+        expect(payload.variables).toEqual({ id: '7' });
+        expect(payload.query).toContain('query Artist($id: ID!)');
+        expect(payload.query).toContain('artist(id: $id)');
+        expect(payload.query).not.toContain('artist(id: "7")');
+    });
+
+    it('keeps operationName and variables in the typed wrapper', async () => {
+        const request = vi.spyOn(axios, 'request').mockResolvedValue({
+            data: { data: { item: { id: '1' } } }
+        });
+
+        await graphQLRequest<'item', { id: string }, { id: string }>({
+            operationName: 'FetchItem',
+            query: 'query FetchItem($id: ID!) { item(id: $id) { id } }',
+            variables: { id: '1' }
+        });
+
+        expect(request).toHaveBeenCalledWith(expect.objectContaining({
+            data: {
+                operationName: 'FetchItem',
+                query: 'query FetchItem($id: ID!) { item(id: $id) { id } }',
+                variables: { id: '1' }
+            }
+        }));
+    });
+});

--- a/server/src/client/src/api/index.ts
+++ b/server/src/client/src/api/index.ts
@@ -18,7 +18,7 @@ export interface AuthSession {
 
 type QueryName = 'query' | 'mutation';
 
-export function wrapper(queryName: QueryName, query: string): string {
+export function wrapper(queryName: QueryName | string, query: string): string {
     return queryName + ' { ' + query + ' }';
 }
 
@@ -34,11 +34,23 @@ interface GraphqlResponse<T extends string, K> {
     };
 }
 
-export async function graphQLRequest<T extends string, K>(query: string): Promise<GraphqlResponse<T, K>> {
+type GraphqlVariables = Record<string, unknown>;
+
+interface GraphqlRequestOptions<TVariables extends GraphqlVariables = GraphqlVariables> {
+    query: string;
+    variables?: TVariables;
+    operationName?: string;
+}
+
+export async function graphQLRequest<T extends string, K, TVariables extends GraphqlVariables = GraphqlVariables>({
+    query,
+    variables,
+    operationName
+}: GraphqlRequestOptions<TVariables>): Promise<GraphqlResponse<T, K>> {
     const { data } = await axios.request<GraphqlResponse<T, K>>({
         url: '/graphql',
         method: 'POST',
-        data: { query }
+        data: { query, variables, operationName }
     });
     return data;
 }
@@ -73,8 +85,9 @@ export async function logoutSession() {
 }
 
 export function getMusics() {
-    return graphQLRequest<'allMusics', Music[]>(
-        wrapper('query', (createQuery<Music>('allMusics', [
+    return graphQLRequest<'allMusics', Music[]>({
+        operationName: 'AllMusics',
+        query: wrapper('query AllMusics', (createQuery<Music>('allMusics', [
             'id',
             'name',
             'filePath',
@@ -98,12 +111,13 @@ export function getMusics() {
                 'publishedYear'
             ])
         ])))
-    );
+    });
 }
 
 export function getArtists() {
-    return graphQLRequest<'allArtists', Artist[]>(
-        wrapper('query', createQuery<Artist>('allArtists', [
+    return graphQLRequest<'allArtists', Artist[]>({
+        operationName: 'AllArtists',
+        query: wrapper('query AllArtists', createQuery<Artist>('allArtists', [
             'id',
             'name',
             'createdAt',
@@ -113,12 +127,14 @@ export function getArtists() {
                 'cover'
             ])
         ]))
-    );
+    });
 }
 
 export function getArtist(id: string) {
-    return graphQLRequest<'artist', Artist>(
-        wrapper('query', createQuery<Artist>(`artist(id: "${id}")`, [
+    return graphQLRequest<'artist', Artist, { id: string }>({
+        operationName: 'Artist',
+        variables: { id },
+        query: wrapper('query Artist($id: ID!)', createQuery<Artist>('artist(id: $id)', [
             'id',
             'name',
             'albumCount',
@@ -137,12 +153,13 @@ export function getArtist(id: string) {
                 'id'
             ])
         ]))
-    );
+    });
 }
 
 export function getAlbums() {
-    return graphQLRequest<'allAlbums', Album[]>(
-        wrapper('query', createQuery<Album>('allAlbums', [
+    return graphQLRequest<'allAlbums', Album[]>({
+        operationName: 'AllAlbums',
+        query: wrapper('query AllAlbums', createQuery<Album>('allAlbums', [
             'id',
             'name',
             'cover',
@@ -153,12 +170,14 @@ export function getAlbums() {
                 'name'
             ])
         ]))
-    );
+    });
 }
 
 export function getAlbum(id: string) {
-    return graphQLRequest<'album', Album>(
-        wrapper('query', createQuery<Album>(`album(id: "${id}")`, [
+    return graphQLRequest<'album', Album, { id: string }>({
+        operationName: 'Album',
+        variables: { id },
+        query: wrapper('query Album($id: ID!)', createQuery<Album>('album(id: $id)', [
             'id',
             'name',
             'cover',
@@ -171,12 +190,13 @@ export function getAlbum(id: string) {
                 'id'
             ])
         ]))
-    );
+    });
 }
 
 export function getPlaylists() {
-    return graphQLRequest<'allPlaylist', Playlist[]>(
-        wrapper('query', createQuery<Playlist>('allPlaylist', [
+    return graphQLRequest<'allPlaylist', Playlist[]>({
+        operationName: 'AllPlaylists',
+        query: wrapper('query AllPlaylists', createQuery<Playlist>('allPlaylist', [
             'id',
             'name',
             'musicCount',
@@ -186,12 +206,14 @@ export function getPlaylists() {
                 'id'
             ])
         ]))
-    );
+    });
 }
 
 export function getPlaylist(id: string) {
-    return graphQLRequest<'playlist', Playlist>(
-        wrapper('query', createQuery<Playlist>(`playlist(id: "${id}")`, [
+    return graphQLRequest<'playlist', Playlist, { id: string }>({
+        operationName: 'Playlist',
+        variables: { id },
+        query: wrapper('query Playlist($id: ID!)', createQuery<Playlist>('playlist(id: $id)', [
             'id',
             'name',
             'musicCount',
@@ -201,7 +223,7 @@ export function getPlaylist(id: string) {
                 'id'
             ])
         ]))
-    );
+    });
 }
 
 export function getAudio(id: string) {
@@ -213,8 +235,9 @@ export function getAudio(id: string) {
 }
 
 export function getLatestSyncReport() {
-    return graphQLRequest<'latestSyncReport', SyncReport | null>(
-        wrapper('query', createQuery<SyncReport>('latestSyncReport', [
+    return graphQLRequest<'latestSyncReport', SyncReport | null>({
+        operationName: 'LatestSyncReport',
+        query: wrapper('query LatestSyncReport', createQuery<SyncReport>('latestSyncReport', [
             'id',
             'createdAt',
             'startedAt',
@@ -264,5 +287,5 @@ export function getLatestSyncReport() {
                 'createdAt'
             ])
         ]))
-    );
+    });
 }

--- a/server/src/client/src/api/query-keys.test.ts
+++ b/server/src/client/src/api/query-keys.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { queryKeys } from './query-keys';
+
+describe('queryKeys', () => {
+    it('uses stable object payloads for detail keys', () => {
+        expect(queryKeys.albums.detail('3')).toEqual(['album', { id: '3' }]);
+        expect(queryKeys.artists.detail('5')).toEqual(['artist', { id: '5' }]);
+        expect(queryKeys.playlists.detail('7')).toEqual(['playlist', { id: '7' }]);
+    });
+
+    it('provides an explicit prefix helper for sync report invalidation', () => {
+        expect(queryKeys.syncReports.listAll()).toEqual(['sync-report']);
+        expect(queryKeys.syncReports.latest()).toEqual(['sync-report', { scope: 'latest' }]);
+    });
+});

--- a/server/src/client/src/api/query-keys.ts
+++ b/server/src/client/src/api/query-keys.ts
@@ -1,0 +1,18 @@
+export const queryKeys = {
+    albums: {
+        all: () => ['albums'] as const,
+        detail: (id?: string) => ['album', { id }] as const
+    },
+    artists: {
+        all: () => ['artists'] as const,
+        detail: (id?: string) => ['artist', { id }] as const
+    },
+    playlists: {
+        all: () => ['playlists'] as const,
+        detail: (id?: string) => ['playlist', { id }] as const
+    },
+    syncReports: {
+        listAll: () => ['sync-report'] as const,
+        latest: () => ['sync-report', { scope: 'latest' }] as const
+    }
+};

--- a/server/src/client/src/pages/AlbumDetail.tsx
+++ b/server/src/client/src/pages/AlbumDetail.tsx
@@ -8,6 +8,7 @@ import { AlbumSummary } from '~/components/album';
 import { Play } from '~/icon';
 
 import { getAlbum } from '~/api';
+import { queryKeys } from '~/api/query-keys';
 
 import { getOriginalImage } from '~/modules/image';
 import { musicStore } from '~/store/music';
@@ -19,7 +20,7 @@ export default function AlbumDetail() {
 
     const { id } = useParams<{ id: string }>();
 
-    const { data: album } = useQuery(['album', id], async () => {
+    const { data: album } = useQuery(queryKeys.albums.detail(id), async () => {
         const { data } = await getAlbum(id!);
         return data.album;
     }, { enabled: !!id });

--- a/server/src/client/src/pages/ArtistDetail.tsx
+++ b/server/src/client/src/pages/ArtistDetail.tsx
@@ -14,6 +14,7 @@ import { Grid, Text } from '~/components/shared';
 import { Play } from '~/icon';
 
 import { getArtist } from '~/api';
+import { queryKeys } from '~/api/query-keys';
 
 import { musicStore } from '~/store/music';
 import { queueStore } from '~/store/queue';
@@ -24,7 +25,7 @@ export default function ArtistDetail() {
 
     const { id } = useParams<{ id: string }>();
 
-    const { data: artist } = useQuery(['artist', id], async () => {
+    const { data: artist } = useQuery(queryKeys.artists.detail(id), async () => {
         const { data } = await getArtist(id!);
         return data.artist;
     }, { enabled: !!id });

--- a/server/src/client/src/pages/PlaylistDetail.tsx
+++ b/server/src/client/src/pages/PlaylistDetail.tsx
@@ -22,6 +22,7 @@ import * as Icon from '~/icon';
 import { panel } from '~/modules/panel';
 
 import { getPlaylist } from '~/api';
+import { queryKeys } from '~/api/query-keys';
 import { toast } from '~/modules/toast';
 import {
     PLAYLIST_CHANGE_MUSIC_ORDER,
@@ -43,7 +44,9 @@ export default function PlaylistDetail() {
 
     const queryClient = useQueryClient();
 
-    const { data: playlist } = useQuery(['playlist', id], () => getPlaylist(id!).then(res => res.data.playlist), { enabled: !!id });
+    const playlistQueryKey = queryKeys.playlists.detail(id);
+
+    const { data: playlist } = useQuery(playlistQueryKey, () => getPlaylist(id!).then(res => res.data.playlist), { enabled: !!id });
 
     const [{ musicMap }] = useStore(musicStore);
 
@@ -59,7 +62,7 @@ export default function PlaylistDetail() {
             const newMusics = arrayMove(playlist.musics, oldIndex, newIndex);
             PlaylistListener.changeMusicOrder(playlist.id, newMusics.map(({ id }) => id));
 
-            queryClient.setQueryData(['playlist', id], () => {
+            queryClient.setQueryData(playlistQueryKey, () => {
                 return {
                     ...playlist,
                     musics: newMusics
@@ -70,7 +73,11 @@ export default function PlaylistDetail() {
 
     useEffect(() => {
         const invalidateQueries = () => {
-            queryClient.invalidateQueries(['playlist', id]);
+            if (!id) {
+                return;
+            }
+
+            queryClient.invalidateQueries(queryKeys.playlists.detail(id), { exact: true });
         };
 
         socket.on(PLAYLIST_MOVE_MUSIC, invalidateQueries);

--- a/server/src/client/src/pages/Setting/components/SynchronizationSection/SynchronizationSection.tsx
+++ b/server/src/client/src/pages/Setting/components/SynchronizationSection/SynchronizationSection.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from 'react-query';
 
 import { Button, SettingSection, SettingItem, Text } from '~/components/shared';
 import { getLatestSyncReport } from '~/api';
+import { queryKeys } from '~/api/query-keys';
 import { toast } from '~/modules/toast';
 import { socket } from '~/socket';
 import type { SyncReport, SyncReportItem } from '~/models/type';
@@ -80,7 +81,7 @@ export const SynchronizationSection = ({ onSyncMusic }: SynchronizationSectionPr
     const [isSyncing, setIsSyncing] = useState(false);
     const queryClient = useQueryClient();
     const { data: latestSyncReport } = useQuery(
-        ['sync-report'],
+        queryKeys.syncReports.latest(),
         () => getLatestSyncReport().then((response) => response.data.latestSyncReport)
     );
     const sections = useMemo(() => reportSections(latestSyncReport ?? null), [latestSyncReport]);
@@ -95,7 +96,7 @@ export const SynchronizationSection = ({ onSyncMusic }: SynchronizationSectionPr
                 }
 
                 setIsSyncing(false);
-                queryClient.invalidateQueries(['sync-report']);
+                queryClient.invalidateQueries(queryKeys.syncReports.listAll(), { exact: false });
                 setTimeout(() => {
                     setProgressMessage('');
                 }, 1000);


### PR DESCRIPTION
## :dart: Goal

Move Ocean Wave client data access closer to the template contract by standardizing GraphQL variables and React Query keys.

## :hammer_and_wrench: Core Changes

- Added a typed GraphQL request shape with query, variables, and operationName.
- Removed dynamic GraphQL id interpolation for artist, album, and playlist detail queries.
- Added a React Query key factory with stable object payloads.
- Replaced direct page-level query key arrays and invalidation keys with factory helpers.
- Added client tests for GraphQL variable payloads and query key shapes.

## :brain: Key Decisions

- Kept React Query v3 in place for this PR and only standardized key creation/invalidation usage.
- Preserved the existing field-selection helper while moving runtime values into variables.
- Used exact invalidation for playlist detail refreshes and a prefix helper for sync report invalidation.

## :test_tube: Verification Guide

- pnpm --filter ocean-wave-client type-check: passes.
- pnpm --filter ocean-wave-client test: passes 16 files / 53 tests.
- pnpm test:ci: passes metadata, server, and client tests.
- pnpm check: passes Biome lint, server/client type-check, and server/client build.
- rg 'artist\(id: "|album\(id: "|playlist\(id: "' server/src/client/src/api -g '!*.test.ts' -n: no matches.

## :white_check_mark: Checklist

- [x] Local validation for the changed scope is complete.
- [x] GraphQL runtime id values are passed as variables.
- [x] React Query keys touched in this PR come from the key factory.
- [x] PR metadata follows the repository template.
