### PR TITLE
🐛 Replace badland stores

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,12 +141,6 @@ importers:
       axios:
         specifier: ^1.13.4
         version: 1.15.2
-      badland:
-        specifier: ^0.2.4
-        version: 0.2.4
-      badland-react:
-        specifier: ^0.0.7
-        version: 0.0.7
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -174,6 +168,9 @@ importers:
       vite-plugin-svgr:
         specifier: ^5.2.0
         version: 5.2.0(rollup@4.60.2)(typescript@6.0.3)(vite@8.0.10(@types/node@25.6.0)(sass@1.99.0))
+      zustand:
+        specifier: ^5.0.12
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.5)
     devDependencies:
       '@types/react':
         specifier: ^19.2.14
@@ -1880,12 +1877,6 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
-
-  badland-react@0.0.7:
-    resolution: {integrity: sha512-cA4/9TQWNovVSeIULlJ1n21Z+4TZz4+kmOEXyIOxyUpQek697zjAc3clQBK6j6PJOby8TH5RJe/evq+8vLtdUw==}
-
-  badland@0.2.4:
-    resolution: {integrity: sha512-PTQ6S7Fb1A3yLZR+kV/bP1O3jUqmWvA9j5xro5rQEjG4gZJMAEoRCndgpufOBNy+Tgz2+pWdkfltekAZTnlOsA==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -4293,6 +4284,24 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zustand@5.0.12:
+    resolution: {integrity: sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@antfu/ni@0.23.2': {}
@@ -6039,10 +6048,6 @@ snapshots:
       '@babel/core': 7.29.0
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
-
-  badland-react@0.0.7: {}
-
-  badland@0.2.4: {}
 
   balanced-match@1.0.2: {}
 
@@ -8666,3 +8671,8 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.5):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5

--- a/server/src/client/package.json
+++ b/server/src/client/package.json
@@ -23,8 +23,6 @@
         "@tanstack/react-query": "^5.100.5",
         "@use-gesture/react": "^10.3.1",
         "axios": "^1.13.4",
-        "badland": "^0.2.4",
-        "badland-react": "^0.0.7",
         "classnames": "^2.5.1",
         "motion": "^12.38.0",
         "react": "^19.2.5",
@@ -33,7 +31,8 @@
         "react-router-dom": "^7.14.2",
         "sass": "^1.97.3",
         "socket.io-client": "^4.8.3",
-        "vite-plugin-svgr": "^5.2.0"
+        "vite-plugin-svgr": "^5.2.0",
+        "zustand": "^5.0.12"
     },
     "devDependencies": {
         "@types/react": "^19.2.14",

--- a/server/src/client/src/App.tsx
+++ b/server/src/client/src/App.tsx
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useEffect, useRef, useState } from 'react';
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { RouterProvider } from 'react-router-dom';
 
 import AuthGate from './components/auth/AuthGate';

--- a/server/src/client/src/components/app/PanelProvider.tsx
+++ b/server/src/client/src/components/app/PanelProvider.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 
 import BottomPanel from '~/components/shared/BottomPanel';
 

--- a/server/src/client/src/components/music/MusicActionPanelContent.tsx
+++ b/server/src/client/src/components/music/MusicActionPanelContent.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 
 import { Image, PanelContent } from '~/components/shared';
 import { PlaylistPanelContent } from '~/components/playlist';

--- a/server/src/client/src/components/music/MusicPlayer/MusicPlayer.tsx
+++ b/server/src/client/src/components/music/MusicPlayer/MusicPlayer.tsx
@@ -2,7 +2,7 @@ import styles from './MusicPlayer.module.scss';
 import classNames from 'classnames/bind';
 const cx = classNames.bind(styles);
 
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useNavigate } from 'react-router-dom';
 
 import { Image } from '~/components/shared';

--- a/server/src/client/src/components/playlist/PlaylistActionPanelContent.tsx
+++ b/server/src/client/src/components/playlist/PlaylistActionPanelContent.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useState } from 'react';
 
 import { useModal } from '~/components/app/ModalProvider';

--- a/server/src/client/src/components/playlist/PlaylistItem/PlaylistItem.tsx
+++ b/server/src/client/src/components/playlist/PlaylistItem/PlaylistItem.tsx
@@ -1,5 +1,5 @@
 import styles from './PlaylistItem.module.scss';
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 
 import GridImage from '../../shared/GridImage';
 import { IconButton } from '~/components/shared';

--- a/server/src/client/src/components/playlist/PlaylistPanelContent.tsx
+++ b/server/src/client/src/components/playlist/PlaylistPanelContent.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 
 import { PanelContent } from '~/components/shared';
 

--- a/server/src/client/src/components/playlist/PlaylistSummary/PlaylistSummary.tsx
+++ b/server/src/client/src/components/playlist/PlaylistSummary/PlaylistSummary.tsx
@@ -2,7 +2,7 @@ import styles from './PlaylistSummary.module.scss';
 import classNames from 'classnames/bind';
 const cx = classNames.bind(styles);
 
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 
 import { GridImage, SummaryTitle } from '~/components/shared';
 

--- a/server/src/client/src/hooks/useStoreValue.ts
+++ b/server/src/client/src/hooks/useStoreValue.ts
@@ -1,6 +1,8 @@
-import type Store from 'badland';
-import { useValue } from 'badland-react';
+import { type BaseStore, useAppStoreValue } from '~/store/base-store';
 
-export default function useStoreValue<T, K extends keyof T>(store: Store<T>, name: K) {
-    return useValue(store, name) as unknown as [T[K], (value: T[K]) => Promise<T>];
+export default function useStoreValue<T extends object, K extends keyof T>(
+    store: BaseStore<T>,
+    name: K
+) {
+    return useAppStoreValue(store, name);
 }

--- a/server/src/client/src/modules/panel.ts
+++ b/server/src/client/src/modules/panel.ts
@@ -1,4 +1,4 @@
-import Store from 'badland';
+import { BaseStore } from '~/store/base-store';
 
 interface PanelStoreState {
     title: string;
@@ -6,7 +6,7 @@ interface PanelStoreState {
     content: React.ReactNode;
 }
 
-class PanelStore extends Store<PanelStoreState> {
+class PanelStore extends BaseStore<PanelStoreState> {
     constructor() {
         super();
         this.state = {

--- a/server/src/client/src/pages/AlbumDetail.tsx
+++ b/server/src/client/src/pages/AlbumDetail.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 

--- a/server/src/client/src/pages/AlbumList.tsx
+++ b/server/src/client/src/pages/AlbumList.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 

--- a/server/src/client/src/pages/ArtistDetail.tsx
+++ b/server/src/client/src/pages/ArtistDetail.tsx
@@ -2,7 +2,7 @@ import styles from './ArtistDetail.module.scss';
 import classNames from 'classnames/bind';
 const cx = classNames.bind(styles);
 
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 

--- a/server/src/client/src/pages/ArtistList.tsx
+++ b/server/src/client/src/pages/ArtistList.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useDeferredValue } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 

--- a/server/src/client/src/pages/Equalizer.tsx
+++ b/server/src/client/src/pages/Equalizer.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useState, useEffect, useCallback } from 'react';
 
 import { useModal } from '~/components/app/ModalProvider';

--- a/server/src/client/src/pages/Favorite.tsx
+++ b/server/src/client/src/pages/Favorite.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useDeferredValue } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 

--- a/server/src/client/src/pages/MusicList.tsx
+++ b/server/src/client/src/pages/MusicList.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useDeferredValue } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 

--- a/server/src/client/src/pages/Player.tsx
+++ b/server/src/client/src/pages/Player.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames/bind';
 const cx = classNames.bind(styles);
 
 import { useNavigate } from 'react-router-dom';
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 
 import { MusicPlayerDiskStyle, MusicPlayerFluffyStyle, MusicPlayerVisualizerStyle } from '~/components/music';
 import { Image, Text } from '~/components/shared';

--- a/server/src/client/src/pages/Playlist.tsx
+++ b/server/src/client/src/pages/Playlist.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 

--- a/server/src/client/src/pages/PlaylistDetail.tsx
+++ b/server/src/client/src/pages/PlaylistDetail.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import type { DragEndEvent } from '@dnd-kit/core';

--- a/server/src/client/src/pages/Queue.tsx
+++ b/server/src/client/src/pages/Queue.tsx
@@ -6,7 +6,7 @@ import type {
     CSSProperties,
     PointerEvent as ReactPointerEvent
 } from 'react';
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Text } from '~/components/shared';

--- a/server/src/client/src/pages/Setting/components/AudioSettingsSection/AudioSettingsSection.tsx
+++ b/server/src/client/src/pages/Setting/components/AudioSettingsSection/AudioSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 import { useNavigate } from 'react-router';
 
 import {

--- a/server/src/client/src/pages/Setting/components/ConnectorsSection/ConnectorsSection.tsx
+++ b/server/src/client/src/pages/Setting/components/ConnectorsSection/ConnectorsSection.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 
 import { SettingSection, Text } from '~/components/shared';
 import { appCopy } from '~/config/copy';

--- a/server/src/client/src/pages/Setting/components/PlayModeSection/PlayModeSection.tsx
+++ b/server/src/client/src/pages/Setting/components/PlayModeSection/PlayModeSection.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 
 import { Select, SettingSection, SettingItem } from '~/components/shared';
 import { queueStore } from '~/store/queue';

--- a/server/src/client/src/pages/Setting/components/ThemeSection/ThemeSection.tsx
+++ b/server/src/client/src/pages/Setting/components/ThemeSection/ThemeSection.tsx
@@ -1,4 +1,4 @@
-import { useStore } from 'badland-react';
+import { useAppStore as useStore } from '~/store/base-store';
 
 import { Select, SettingSection, SettingItem } from '~/components/shared';
 import { themeStore } from '~/store/theme';

--- a/server/src/client/src/store/album.ts
+++ b/server/src/client/src/store/album.ts
@@ -1,4 +1,4 @@
-import Store from 'badland';
+import { BaseStore } from './base-store';
 
 import type { Album } from '~/models/type';
 
@@ -23,7 +23,7 @@ interface AlbumStoreState {
     sortedFrom: typeof SORT_STATE[keyof typeof SORT_STATE];
 }
 
-class AlbumStore extends Store<AlbumStoreState> {
+class AlbumStore extends BaseStore<AlbumStoreState> {
     init = false;
 
     constructor() {

--- a/server/src/client/src/store/artist.ts
+++ b/server/src/client/src/store/artist.ts
@@ -1,4 +1,4 @@
-import Store from 'badland';
+import { BaseStore } from './base-store';
 
 import type { Artist } from '~/models/type';
 
@@ -23,7 +23,7 @@ interface ArtistStoreState {
     sortedFrom: typeof SORT_STATE[keyof typeof SORT_STATE];
 }
 
-class ArtistStore extends Store<ArtistStoreState> {
+class ArtistStore extends BaseStore<ArtistStoreState> {
     init = false;
 
     constructor() {

--- a/server/src/client/src/store/audio-settings.ts
+++ b/server/src/client/src/store/audio-settings.ts
@@ -1,4 +1,4 @@
-import Store from 'badland';
+import { BaseStore } from './base-store';
 
 export interface AudioSettings {
     format: 'mp3' | 'aac';
@@ -6,7 +6,7 @@ export interface AudioSettings {
     useOriginal: boolean;
 }
 
-class AudioSettingsStore extends Store<AudioSettings> {
+class AudioSettingsStore extends BaseStore<AudioSettings> {
     constructor() {
         super();
 

--- a/server/src/client/src/store/base-store.test.ts
+++ b/server/src/client/src/store/base-store.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { BaseStore } from './base-store';
+
+interface TestState {
+    count: number;
+    label: string;
+}
+
+class TestStore extends BaseStore<TestState> {
+    changes: Array<{
+        state: TestState;
+        previousState: TestState;
+    }> = [];
+
+    afterStateChange(state: TestState, previousState: TestState) {
+        this.changes.push({ state, previousState });
+    }
+}
+
+const createTestStore = () => {
+    const store = new TestStore();
+
+    store.state = {
+        count: 0,
+        label: 'ready'
+    };
+    return store;
+};
+
+describe('BaseStore', () => {
+    it('sets the initial state without running change side effects', () => {
+        const store = createTestStore();
+
+        expect(store.state).toEqual({
+            count: 0,
+            label: 'ready'
+        });
+        expect(store.changes).toEqual([]);
+    });
+
+    it('merges partial updates and reports the previous state', () => {
+        const store = createTestStore();
+        const previousState = store.state;
+        const nextState = store.set({ count: 1 });
+
+        expect(nextState).toEqual({
+            count: 1,
+            label: 'ready'
+        });
+        expect(store.changes).toEqual([{
+            state: nextState,
+            previousState
+        }]);
+    });
+
+    it('supports functional updates and unsubscribe handles', () => {
+        const store = createTestStore();
+        const listener = vi.fn();
+        const unsubscribe = store.subscribe(listener);
+
+        store.set((state) => ({
+            label: `${state.label}!`
+        }));
+        store.unsubscribe(unsubscribe);
+        store.set({ count: 2 });
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(listener).toHaveBeenCalledWith({
+            count: 0,
+            label: 'ready!'
+        }, {
+            count: 0,
+            label: 'ready'
+        });
+        expect(store.state).toEqual({
+            count: 2,
+            label: 'ready!'
+        });
+    });
+});

--- a/server/src/client/src/store/base-store.ts
+++ b/server/src/client/src/store/base-store.ts
@@ -1,0 +1,64 @@
+import { useStore as useZustandStore } from 'zustand';
+import { createStore, type StoreApi } from 'zustand/vanilla';
+
+type StoreStateUpdater<T extends object> = T | Partial<T> | ((state: T) => T | Partial<T>);
+type StoreSubscriber<T extends object> = (state: T, previousState: T) => void;
+
+export class BaseStore<T extends object> {
+    readonly api: StoreApi<T>;
+    private hasInitialState = false;
+
+    constructor() {
+        this.api = createStore<T>()(() => ({} as T));
+    }
+
+    get state() {
+        return this.api.getState();
+    }
+
+    set state(state: T) {
+        const previousState = this.api.getState();
+
+        this.api.setState(state, true);
+        if (this.hasInitialState) {
+            this.afterStateChange(this.api.getState(), previousState);
+            return;
+        }
+        this.hasInitialState = true;
+    }
+
+    set = (partial: StoreStateUpdater<T>) => {
+        const previousState = this.api.getState();
+
+        this.api.setState(partial);
+        this.afterStateChange(this.api.getState(), previousState);
+        return this.api.getState();
+    };
+
+    setState = (partial: StoreStateUpdater<T>) => {
+        return this.set(partial);
+    };
+
+    subscribe(listener: StoreSubscriber<T>) {
+        return this.api.subscribe(listener);
+    }
+
+    unsubscribe(unsubscribe: () => void) {
+        unsubscribe();
+    }
+
+    afterStateChange(_state: T, _previousState: T) {}
+}
+
+export function useAppStore<T extends object>(store: BaseStore<T>) {
+    void store.state;
+    return [useZustandStore(store.api), store.setState] as const;
+}
+
+export function useAppStoreValue<T extends object, K extends keyof T>(
+    store: BaseStore<T>,
+    name: K
+) {
+    void store.state;
+    return [useZustandStore(store.api, (state) => state[name]), store.setState] as const;
+}

--- a/server/src/client/src/store/connector.ts
+++ b/server/src/client/src/store/connector.ts
@@ -1,4 +1,4 @@
-import Store from 'badland';
+import { BaseStore } from './base-store';
 import type { Connector } from '~/socket';
 import { ConnectorListener, socket } from '~/socket';
 
@@ -6,7 +6,7 @@ interface ConnectorStoreState {
     connectors: Connector[];
 }
 
-class ConnectorStore extends Store<ConnectorStoreState> {
+class ConnectorStore extends BaseStore<ConnectorStoreState> {
     init = false;
     listener: ConnectorListener;
 

--- a/server/src/client/src/store/equalizer.ts
+++ b/server/src/client/src/store/equalizer.ts
@@ -1,4 +1,4 @@
-import Store from 'badland';
+import { BaseStore } from './base-store';
 
 interface EqualizerState {
     bass: number;
@@ -8,7 +8,7 @@ interface EqualizerState {
     treble: number;
 }
 
-class EqualizerStore extends Store<EqualizerState> {
+class EqualizerStore extends BaseStore<EqualizerState> {
     saveTimer: ReturnType<typeof setTimeout> | null;
 
     constructor() {

--- a/server/src/client/src/store/music.ts
+++ b/server/src/client/src/store/music.ts
@@ -1,4 +1,4 @@
-import Store from 'badland';
+import { BaseStore } from './base-store';
 
 import type { Music } from '~/models/type';
 
@@ -27,7 +27,7 @@ interface MusicStoreState {
     sortedFrom: typeof SORT_STATE[keyof typeof SORT_STATE];
 }
 
-class MusicStore extends Store<MusicStoreState> {
+class MusicStore extends BaseStore<MusicStoreState> {
     init = false;
     listener: MusicListener;
 

--- a/server/src/client/src/store/playlist.ts
+++ b/server/src/client/src/store/playlist.ts
@@ -1,4 +1,4 @@
-import Store from 'badland';
+import { BaseStore } from './base-store';
 import { getPlaylists } from '~/api';
 import type { Playlist } from '~/models/type';
 import { PlaylistListener } from '~/socket';
@@ -8,7 +8,7 @@ interface PlaylistStoreState {
     playlists: Playlist[];
 }
 
-class PlaylistStore extends Store<PlaylistStoreState> {
+class PlaylistStore extends BaseStore<PlaylistStoreState> {
     init = false;
     listener: PlaylistListener;
 

--- a/server/src/client/src/store/queue.ts
+++ b/server/src/client/src/store/queue.ts
@@ -1,4 +1,4 @@
-import Store from 'badland';
+import { BaseStore } from './base-store';
 
 import { musicStore } from './music';
 
@@ -53,7 +53,7 @@ const createQueueState = (items: string[], selected: number | null) => ({
     ...deriveQueueState(items, selected)
 });
 
-class QueueStore extends Store<QueueStoreState> {
+class QueueStore extends BaseStore<QueueStoreState> {
     saveTimer: ReturnType<typeof setTimeout> | null = null;
     audioChannel: AudioChannel;
     playbackSessionTracker: PlaybackSessionTracker;

--- a/server/src/client/src/store/theme.ts
+++ b/server/src/client/src/store/theme.ts
@@ -1,10 +1,10 @@
-import Store from 'badland';
+import { BaseStore } from './base-store';
 
 interface ThemeState {
     playerAlbumArtStyle: string;
 }
 
-class ThemeStore extends Store<ThemeState> {
+class ThemeStore extends BaseStore<ThemeState> {
     constructor() {
         super();
         this.state = { playerAlbumArtStyle: localStorage.getItem('theme:playerAlbumArtStyle') || '' };


### PR DESCRIPTION
## :dart: Goal
Fix the client runtime error caused by the badland Store constructor path after the Vite/Rolldown stack upgrade, and move Ocean Wave client stores to zustand.

## :hammer_and_wrench: Core Changes
- Added a zustand-backed BaseStore compatibility layer for state, set, subscribe, unsubscribe, and React hooks.
- Swapped all badland and badland-react imports to the new store helper.
- Replaced badland/badland-react dependencies with zustand.
- Added BaseStore unit coverage for initial state, updates, and unsubscribe behavior.

## :brain: Key Decisions
- Kept existing store class APIs to avoid touching queue/player/playlist behavior while removing the failing constructor dependency.
- Preserved lazy store bootstrapping by reading store.state before subscribing through the zustand React hook.
- Skipped initial afterStateChange side effects so queue/equalizer persistence does not fire during constructor setup.

## :test_tube: Verification Guide
- `npx -y node@22.12.0 $(which pnpm) --filter ocean-wave-client type-check` passed.
- `npx -y node@22.12.0 $(which pnpm) --filter ocean-wave-client lint` passed.
- `npx -y node@22.12.0 $(which pnpm) --filter ocean-wave-client test` passed: 15 files, 49 tests.
- `npx -y node@22.12.0 $(which pnpm) check` passed.
- `npx -y node@22.12.0 $(which pnpm) test:ci` passed.

## :white_check_mark: Checklist
- [x] PR title follows project convention.
- [x] Commit title follows project convention.
- [x] Local validation completed for changed scope.
- [x] Dependency changes are reflected in pnpm-lock.yaml.